### PR TITLE
feat: centralized UI locators, Manager-first targeting, file-system chat extraction & new commands

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -13,7 +13,9 @@
     "status_title": "👁️ <i>Status &amp; Info:</i>",
     "status_text": "- /latest → Get latest response (cleaned)\n- /screenshot → Take IDE screenshot\n- /status → System status (IDE, CDP, PM2)",
     "ide_title": "🛠️ <i>IDE Controls:</i>",
-    "ide_text": "- /start_ide → Start the IDE if closed\n- /close → Fully close the IDE (kill process + clean locks)\n- /new → Open a new chat\n- /model → Open model selection menu\n- /workspace → Switch project workspace\n- /window → Select active IDE window\n- /autoaccept → Toggle auto-accept on/off\n- /lang → Switch language\n- /cmd &lt;command&gt; → Run a terminal command\n- /help → Show this help message"
+    "ide_text": "- /start_ide → Start the IDE if closed\n- /close → Fully close the IDE (kill process + clean locks)\n- /workspace → Switch project workspace\n- /window → Select active IDE window\n- /lang → Switch language\n- /cmd &lt;command&gt; → Run a terminal command\n- /help → Show this help message",
+    "chat_title": "💬 <i>Chat Controls:</i>",
+    "chat_text": "- /new → Open a new chat\n- /agents → List and switch recent chat threads\n- /artifacts → List artifacts of current thread\n- /model → Open model selection menu\n- /autoaccept → Toggle auto-accept on/off"
   },
   "ide": {
     "already_running": "✅ Antigravity IDE is already running! No need to open another window.\n💡 Use /close to shut it down.",
@@ -109,6 +111,8 @@
     "close_desc": "Close entire IDE",
     "close_window_desc": "Close current window",
     "new_desc": "Open new chat",
+    "agents_desc": "List and switch recent chat threads",
+    "artifacts_desc": "List artifacts of current thread",
     "model_desc": "Open model selection menu",
     "workspace_desc": "Switch project",
     "lang_desc": "Switch language",
@@ -169,7 +173,22 @@
     "cleared_toast": "Cleared — using auto-detect",
     "cleared_msg": "🔄 Window preference cleared. Bot will auto-detect the active IDE window.",
     "expired": "Window list expired. Send /window again.",
-    "selected_toast": "Selected: {{title}}",
     "selected_msg": "✅ Now targeting: <b>{{title}}</b>\n\nAll commands will route to this window."
+  },
+  "agents": {
+    "list_title": "📂 <b>Recent Chat Threads:</b>\n\n",
+    "switched": "✅ Switched to thread: <b>{name}</b>",
+    "not_found": "❌ Thread could not be selected.",
+    "invalid_number": "❌ Invalid thread number.",
+    "no_recent": "ℹ️ No recent active threads found.",
+    "error": "❌ Error: {error}"
+  },
+  "artifacts": {
+    "list_title": "📎 <b>Artifacts for Current Thread:</b>\n\n",
+    "no_active_thread": "⚠️ No active thread found. Please select a thread in the IDE first.",
+    "no_artifacts": "ℹ️ No artifacts found for the current thread.",
+    "invalid_number": "❌ Invalid artifact number.",
+    "sending": "📤 Sending artifact: <b>{name}</b>...",
+    "error": "❌ Error reading artifact: {error}"
   }
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -13,7 +13,9 @@
     "status_title": "👁️ <i>Durum &amp; Bilgi:</i>",
     "status_text": "- /latest → Son yanıtı getirir (temizlenmiş)\n- /screenshot → IDE ekran görüntüsü alır\n- /status → Sistem durumu (IDE, CDP, PM2)",
     "ide_title": "🛠️ <i>IDE Kontrolleri:</i>",
-    "ide_text": "- /start_ide → IDE kapalıysa başlatır\n- /close → IDE'yi tamamen kapatır (tüm process + lock temizler)\n- /new → Yeni sohbet açar\n- /model → Model seçimi menüsünü açar\n- /workspace → Projeyi değiştirir\n- /window → Aktif IDE penceresini seçer\n- /autoaccept → Otomatik kabul aç/kapat\n- /lang → Dil değiştirir\n- /cmd &lt;komut&gt; → Terminalde komut çalıştırır\n- /help → Bu yardım mesajını gösterir"
+    "ide_text": "- /start_ide → IDE kapalıysa başlatır\n- /close → IDE'yi tamamen kapatır (tüm process + lock temizler)\n- /workspace → Projeyi değiştirir\n- /window → Aktif IDE penceresini seçer\n- /lang → Dil değiştirir\n- /cmd &lt;komut&gt; → Terminalde komut çalıştırır\n- /help → Bu yardım mesajını gösterir",
+    "chat_title": "💬 <i>Sohbet Kontrolleri:</i>",
+    "chat_text": "- /new → Yeni sohbet açar\n- /agents → Son sohbetleri listeler ve değiştirir\n- /artifacts → Mevcut sohbetin artifact'lerini listeler\n- /model → Model seçimi menüsünü açar\n- /autoaccept → Otomatik kabul aç/kapat"
   },
   "ide": {
     "already_running": "✅ Antigravity IDE zaten çalışıyor! Ekstra pencere açmaya gerek yok.\n💡 Kapatmak için /close yazabilirsiniz.",
@@ -109,6 +111,8 @@
     "close_desc": "IDE tamamen kapatır",
     "close_window_desc": "Mevcut pencereyi kapatır",
     "new_desc": "Yeni sohbet açar",
+    "agents_desc": "Son sohbetleri listeler ve değiştirir",
+    "artifacts_desc": "Mevcut sohbetin artifact'lerini listeler",
     "model_desc": "Model seçimi menüsünü açar",
     "workspace_desc": "Projeyi değiştirir",
     "lang_desc": "Dil değiştirir",
@@ -169,7 +173,22 @@
     "cleared_toast": "Temizlendi — otomatik seçim devrede",
     "cleared_msg": "🔄 Pencere tercihi temizlendi. Bot aktif IDE penceresini otomatik algılayacak.",
     "expired": "Pencere listesi süresi doldu. Tekrar /window gönderin.",
-    "selected_toast": "Seçildi: {{title}}",
     "selected_msg": "✅ Yeni hedef: <b>{{title}}</b>\n\nTüm komutlar artık bu pencereye gönderilecek."
+  },
+  "agents": {
+    "list_title": "📂 <b>Son Sohbetler:</b>\n\n",
+    "switched": "✅ Sohbet değiştirildi: <b>{name}</b>",
+    "not_found": "❌ Sohbet seçilemedi.",
+    "invalid_number": "❌ Geçersiz sohbet numarası.",
+    "no_recent": "ℹ️ Son aktif sohbet bulunamadı.",
+    "error": "❌ Hata: {error}"
+  },
+  "artifacts": {
+    "list_title": "📎 <b>Mevcut Sohbetin Artifact'leri:</b>\n\n",
+    "no_active_thread": "⚠️ Aktif sohbet bulunamadı. Lütfen IDE'den bir sohbet seçin.",
+    "no_artifacts": "ℹ️ Mevcut sohbet için artifact bulunamadı.",
+    "invalid_number": "❌ Geçersiz artifact numarası.",
+    "sending": "📤 Gönderiliyor: <b>{name}</b>...",
+    "error": "❌ Artifact okuma hatası: {error}"
   }
 }

--- a/src/autoaccept.js
+++ b/src/autoaccept.js
@@ -93,7 +93,7 @@ function buildObserverScript() {
     var ALLOWED_COMMANDS = ${JSON.stringify(allowedCommands)};
     var HAS_FILTERS = BLOCKED_COMMANDS.length > 0 || ALLOWED_COMMANDS.length > 0;
 
-    window.__AA_BOT_CLICK_COUNT = window.__AA_BOT_CLICK_COUNT || 0;
+    window.__AA_BOT_CLICK_COUNT = 0;
     window.__AA_BOT_CLICK_LOG = window.__AA_BOT_CLICK_LOG || [];
     window.__AA_BOT_PAUSED = false;
     window.__AA_BOT_LAST_SCAN = Date.now();
@@ -511,8 +511,35 @@ async function disable(port) {
         heartbeatTimer = null;
     }
 
-    // Kill our observer in all targets
+    // Final click harvest — capture any clicks that occurred since the last heartbeat
     const targets = await resolveTargets(port, true).catch(() => []);
+    for (const target of targets) {
+        if (!injectedTargets.has(target.id)) continue;
+        try {
+            const health = await cdpEval(target.webSocketDebuggerUrl, `
+                (function() {
+                    return {
+                        clicks: window.__AA_BOT_CLICK_COUNT || 0,
+                        log: (window.__AA_BOT_CLICK_LOG || []).slice(-5)
+                    };
+                })()
+            `);
+            if (health && health.clicks > sessionClicks) {
+                const delta = health.clicks - sessionClicks;
+                totalClicks += delta;
+                sessionClicks = health.clicks;
+            }
+            if (health && health.log) {
+                for (const cl of health.log) {
+                    console.log(`[autoaccept] CLICK (final harvest): ${cl.text} (${cl.tag})`);
+                    lastClickText = cl.text;
+                    lastClickTime = cl.time || Date.now();
+                }
+            }
+        } catch (_) {}
+    }
+
+    // Kill our observer in all targets
     for (const target of targets) {
         try {
             await cdpEval(target.webSocketDebuggerUrl, `

--- a/src/cdp_controller.js
+++ b/src/cdp_controller.js
@@ -1,5 +1,8 @@
 const CDP = require('chrome-remote-interface');
 const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
 // Store the previous full chat state to filter out old messages
 let globalLastChatState = "";
@@ -18,6 +21,11 @@ let windowCache = [];
  * @param {boolean} includeIframe - whether to include iframe/webview types
  * @returns {Promise<Array>} sorted array of CDP target objects
  */
+const { UI_LOCATORS_SCRIPT } = require('./ui_locators');
+
+// Cache for the active workspace name, refreshed on each resolveTargets call
+let activeWorkspaceName = null;
+
 async function resolveTargets(port, includeIframe = true) {
     const raw = await httpGet(`http://127.0.0.1:${port}/json`);
     const targets = JSON.parse(raw);
@@ -29,16 +37,60 @@ async function resolveTargets(port, includeIframe = true) {
         !t.url.includes('devtools://') &&
         !(t.title && t.title.includes('Launchpad')));
 
+    // Query the Manager target's top bar for the active workspace name.
+    // The Manager renders a breadcrumb like "workspace-name / Thread Title"
+    // in the header bar, making it trivial to extract the active workspace.
+    try {
+        const manager = candidates.find(t => t.title === 'Manager');
+        if (manager) {
+            const client = await CDP({ target: manager.webSocketDebuggerUrl });
+            const { Runtime } = client;
+            await Runtime.enable();
+            const res = await Runtime.evaluate({
+                expression: `
+                    (() => {
+                        // Find top-bar elements (y < 40px, narrow height, wide)
+                        const topEls = Array.from(document.querySelectorAll('div')).filter(el => {
+                            const r = el.getBoundingClientRect();
+                            return r.y >= 0 && r.y < 40 && r.height < 50 && r.height > 20 && r.width > 200;
+                        });
+                        for (const el of topEls) {
+                            const text = el.innerText.replace(/\\n/g, ' ').trim();
+                            // Match the breadcrumb format: "... workspace-name / Thread Title ..."
+                            // Strip leading icon text (arrow_back, arrow_forward, dock_to_right)
+                            const cleaned = text.replace(/^(arrow_back|arrow_forward|dock_to_right|\\s)+/g, '').trim();
+                            const slashIdx = cleaned.indexOf(' / ');
+                            if (slashIdx > 0) {
+                                return cleaned.substring(0, slashIdx).trim();
+                            }
+                        }
+                        return null;
+                    })()
+                `,
+                returnByValue: true
+            });
+            await client.close();
+            if (res.result?.value) {
+                activeWorkspaceName = res.result.value.toLowerCase();
+            }
+        }
+    } catch (_) {
+        // Non-critical — if we can't query the Manager, we just keep the last cached value
+    }
+
     candidates.sort((a, b) => {
-        // Preferred target by ID always wins
+        // Preferred target by ID always wins (set via /window command)
         if (preferredTargetId) {
             if (a.id === preferredTargetId) return -1;
             if (b.id === preferredTargetId) return 1;
         }
-        // Fallback: prefer 'antigravity' in title
-        const aMatch = a.title.toLowerCase().includes('antigravity') ? 1 : 0;
-        const bMatch = b.title.toLowerCase().includes('antigravity') ? 1 : 0;
-        return bMatch - aMatch;
+        // Dynamic fallback: prefer the target matching the active workspace
+        if (activeWorkspaceName) {
+            const aMatch = a.title.toLowerCase().includes(activeWorkspaceName) ? 1 : 0;
+            const bMatch = b.title.toLowerCase().includes(activeWorkspaceName) ? 1 : 0;
+            if (aMatch !== bMatch) return bMatch - aMatch;
+        }
+        return 0;
     });
 
     return candidates;
@@ -73,47 +125,75 @@ function getCachedWindows() {
 }
 
 
-// DOM extraction expression (shared between snapshot and getLatest)
 const CHAT_EXTRACT_EXPR = `
+    ${UI_LOCATORS_SCRIPT}
     (function() {
         let extractedText = "";
         try {
-            const container = document.querySelector('.flex.w-full.grow.flex-col.overflow-hidden, #conversation, #chat, .interactive-session');
-            if (container) {
-                const buttons = Array.from(container.querySelectorAll('button')).filter(btn => btn.innerText && btn.innerText.includes('Thought for'));
-                const hiddenEls = [];
-                buttons.forEach(btn => {
-                    if (btn.parentElement) {
-                        hiddenEls.push({ el: btn.parentElement, display: btn.parentElement.style.display });
-                        btn.parentElement.style.setProperty('display', 'none', 'important');
-                    }
-                });
-                extractedText = container.innerText || container.textContent || "";
-                hiddenEls.forEach(item => { item.el.style.display = item.display; });
+            // Use the centralized locator to find the active conversation
+            const container = AG_UI.getVisibleChatContainer();
+            
+            function cleanText(text) {
+                if (!text) return "";
+                text = text.replace(/Ask anything.*?for workflows/gi, '');
+                text = text.replace(/0 Files With Changes/g, '');
+                text = text.replace(/Review Changes/g, '');
+                text = text.replace(/Gemini[\\s\\d\\.]+Pro[\\s]*\\([^)]*\\)/gi, '');
+                text = text.replace(/Claude[\\s\\w\\.]+\\([^)]*\\)/gi, '');
+                text = text.replace(/GPT[\\s\\w\\.]+\\([^)]*\\)/gi, '');
+                text = text.replace(/\\bSend\\b\\s*\\b(mic)?\\b/gi, '');
+                text = text.replace(/\\bmic\\b/gi, '');
+                text = text.replace(/Worked for \\d+s/gi, '');
+                text = text.replace(/\\b\\d{1,2}:\\d{2}(?:\\s*(?:AM|PM))?\\b/ig, '');
+                text = text.replace(/Thinking.../g, "").replace(/Gelişim App Dev/g, "");
+
+                text = text.replace(/^\\s*(Plan|Execute|Review|Task|Walkthrough|Implementation Plan)\\s*$/gm, '');
+                text = text.replace(/undo/g, '');
+                text = text.replace(/chevron_right/g, '');
+                text = text.replace(/chevron_left/g, '');
+                text = text.replace(/content_copy/g, '');
+                text = text.replace(/thumb_up/g, '');
+                text = text.replace(/thumb_down/g, '');
+                text = text.replace(/Files Modified[\\s\\n]*(\\d+)[\\s\\n]*([a-zA-Z0-9_\\-\\.]+)[\\s\\n]*\\+([0-9]+)[\\s\\n]*\\-([0-9]+)/gi, "\\n[📦 Files Modified: $2 (+$3, -$4)]\\n");
+                text = text.replace(/\\n{3,}/g, '\\n\\n');
+                return text.trim();
             }
-            extractedText = extractedText.replace(/Ask anything.*?for workflows/gi, '');
-            extractedText = extractedText.replace(/0 Files With Changes/g, '');
-            extractedText = extractedText.replace(/Review Changes/g, '');
-            extractedText = extractedText.replace(/Gemini[\\s\\d\\.]+Pro[\\s]*\\([^)]*\\)/gi, '');
-            extractedText = extractedText.replace(/Claude[\\s\\w\\.]+\\([^)]*\\)/gi, '');
-            extractedText = extractedText.replace(/GPT[\\s\\w\\.]+\\([^)]*\\)/gi, '');
-            extractedText = extractedText.replace(/\\bSend\\b\\s*\\b(mic)?\\b/gi, '');
-            extractedText = extractedText.replace(/\\bmic\\b/gi, '');
-            extractedText = extractedText.replace(/Files Modified[\\s\\n]*(\\d+)[\\s\\n]*([a-zA-Z0-9_\\-\\.]+)[\\s\\n]*\\+([0-9]+)[\\s\\n]*\\-([0-9]+)/gi, "\\n[📦 Files Modified: $2 (+$3, -$4)]\\n");
-            extractedText = extractedText.replace(/chevron_left/g, '');
-            extractedText = extractedText.replace(/chevron_right/g, '');
-            extractedText = extractedText.replace(/content_copy/g, '');
-            extractedText = extractedText.replace(/thumb_up/g, '');
-            extractedText = extractedText.replace(/thumb_down/g, '');
-            extractedText = extractedText.replace(/undo/g, '');
-            extractedText = extractedText.replace(/Worked for \\d+s/gi, '');
-            extractedText = extractedText.replace(/\\d{1,2}:\\d{2}\\s*(?:AM|PM)/ig, '');
-            extractedText = extractedText.replace(/Thinking.../g, "").replace(/Gelişim App Dev/g, "");
-            extractedText = extractedText.replace(/Thought for \\d+s\\s*Prioritizing Tool Usage[\\s\\S]*?(?=\\n\\n|$)/gi, "");
-            extractedText = extractedText.replace(/Prioritizing Tool Usage[\\s\\S]*?(?=\\n\\n|$)/gi, "");
-            extractedText = extractedText.replace(/I'm now focusing on tool selection[\\s\\S]*?(?=\\n\\n|$)/gi, "");
-            extractedText = extractedText.replace(/Thought for \\d+s/gi, "");
-            extractedText = extractedText.trim();
+
+            if (container) {
+                const list = container.querySelector('.relative.flex.flex-col.gap-y-3.px-4, .monaco-list-rows');
+                if (list) {
+                    const msgs = [];
+                    for (let child of list.children) {
+                        let isUser = !!child.querySelector('.bg-input');
+                        let clone = child.cloneNode(true);
+                        
+                        Array.from(clone.querySelectorAll('style, .material-icons, [class*="icon"]')).forEach(el => el.remove());
+                        
+                        // Use centralized logic to remove Thought blocks
+                        AG_UI.removeThoughtBlocks(clone);
+                        
+                        Array.from(clone.querySelectorAll('button')).forEach(el => el.remove());
+                        
+                        if (isUser) {
+                            const userInput = clone.querySelector('.bg-input');
+                            let uText = userInput ? userInput.innerText : "";
+                            if (userInput) userInput.remove();
+                            
+                            uText = cleanText(uText);
+                            if (uText) msgs.push("👤 User:\\n" + uText);
+                            
+                            let aText = cleanText(clone.innerText);
+                            if (aText) msgs.push("🤖 Agent:\\n" + aText);
+                        } else {
+                            let aText = cleanText(clone.innerText);
+                            if (aText) msgs.push("🤖 Agent:\\n" + aText);
+                        }
+                    }
+                    extractedText = msgs.join('\\n\\n');
+                } else {
+                    extractedText = cleanText(container.innerText || container.textContent || "");
+                }
+            }
         } catch(e) {}
         return String(extractedText);
     })()
@@ -133,7 +213,45 @@ function httpGet(url) {
  * Snapshot the current chat state so subsequent getLatestAgentResponse
  * calls only return text that appeared AFTER this snapshot.
  */
+// Track the last step_index we've seen for file-based diffing
+let lastSeenStepIndex = -1;
+
+/**
+ * Snapshot the current chat state for diff tracking.
+ * Now simply records the last step_index from the active thread's log file.
+ */
 async function snapshotChatState(port) {
+    try {
+        const activeId = await getActiveThreadId(port);
+        if (!activeId) return;
+        const logPath = path.join(os.homedir(), '.gemini', 'antigravity', 'brain', activeId, '.system_generated', 'logs', 'overview.txt');
+        if (!fs.existsSync(logPath)) return;
+        
+        const stats = fs.statSync(logPath);
+        const readSize = Math.min(stats.size, 5000);
+        const fd = fs.openSync(logPath, 'r');
+        const buf = Buffer.alloc(readSize);
+        fs.readSync(fd, buf, 0, readSize, stats.size - readSize);
+        fs.closeSync(fd);
+        const tail = buf.toString('utf8');
+        const lines = tail.split('\n').filter(l => l.trim());
+        
+        // Find the highest step_index
+        for (let i = lines.length - 1; i >= 0; i--) {
+            try {
+                const entry = JSON.parse(lines[i]);
+                if (entry.step_index !== undefined) {
+                    lastSeenStepIndex = entry.step_index;
+                    console.log(`[snapshot] Anchored at step_index ${lastSeenStepIndex}`);
+                    return;
+                }
+            } catch (_) {}
+        }
+    } catch (e) {
+        console.log('[snapshot] File-based snapshot failed:', e.message);
+    }
+    
+    // DOM fallback for legacy behavior
     const candidates = await resolveTargets(port);
     for (const target of candidates) {
         try {
@@ -145,82 +263,115 @@ async function snapshotChatState(port) {
             await client.close();
             if (val && val.length > 0) {
                 globalLastChatState = val;
-                console.log(`[snapshot] Chat state anchored (${val.length} chars)`);
+                console.log(`[snapshot] DOM fallback anchored (${val.length} chars)`);
                 return;
             }
         } catch (_) {}
     }
 }
 
-async function getLatestAgentResponse(port) {
-    const candidates = await resolveTargets(port);
+/**
+ * Get the latest agent response since the last snapshot.
+ * 
+ * Primary strategy: Read new entries from the active thread's overview.txt
+ * since the last snapshotted step_index. This avoids stale DOM issues and
+ * timestamp bleed from the DOM extraction.
+ * 
+ * Falls back to DOM extraction if the file doesn't exist.
+ */
 
-    const logs = [];
+/**
+ * Get the full last agent response block (no diffing).
+ * Used by /latest command.
+ * 
+ * Strategy: Read from the file system instead of the DOM, because the IDE's
+ * workspace DOM often retains stale content from previously-viewed threads.
+ * 
+ * 1. Get the active thread ID from the Manager sidebar (reliable)
+ * 2. Read the thread's overview.txt log file from disk
+ * 3. Parse the last user message + model response from the log
+ * 4. Fall back to DOM extraction only if the file doesn't exist
+ */
+async function getFullLatestResponse(port) {
+    // --- Primary: file-system extraction from the active thread's log ---
+    try {
+        const activeId = await getActiveThreadId(port);
+        if (activeId) {
+            const logPath = path.join(os.homedir(), '.gemini', 'antigravity', 'brain', activeId, '.system_generated', 'logs', 'overview.txt');
+            if (fs.existsSync(logPath)) {
+                // Read the last ~20KB of the file (enough for recent messages)
+                const stats = fs.statSync(logPath);
+                const readSize = Math.min(stats.size, 20000);
+                const fd = fs.openSync(logPath, 'r');
+                const buf = Buffer.alloc(readSize);
+                fs.readSync(fd, buf, 0, readSize, stats.size - readSize);
+                fs.closeSync(fd);
+                const tail = buf.toString('utf8');
+                
+                // Parse JSON lines to find the last user message + model content response
+                const lines = tail.split('\n').filter(l => l.trim());
+                let lastUserMsg = null;
+                let lastModelMsg = null;
+                
+                for (let i = lines.length - 1; i >= 0; i--) {
+                    try {
+                        const entry = JSON.parse(lines[i]);
+                        if (!lastModelMsg && entry.source === 'MODEL' && entry.content && entry.content.trim()) {
+                            lastModelMsg = entry.content;
+                        }
+                        if (lastModelMsg && !lastUserMsg && entry.source === 'USER_EXPLICIT' && entry.content) {
+                            // Extract just the user request from the XML wrapper
+                            const reqMatch = entry.content.match(/<USER_REQUEST>\n?([\s\S]*?)\n?<\/USER_REQUEST>/);
+                            lastUserMsg = reqMatch ? reqMatch[1].trim() : entry.content.substring(0, 200);
+                        }
+                        if (lastUserMsg && lastModelMsg) break;
+                    } catch (_) {}
+                }
+                
+                if (lastModelMsg) {
+                    const parts = [];
+                    if (lastUserMsg) parts.push('👤 User:\n' + lastUserMsg);
+                    // Truncate very long model responses for Telegram
+                    const truncated = lastModelMsg.length > 3000 ? lastModelMsg.substring(0, 3000) + '\n\n[...truncated]' : lastModelMsg;
+                    parts.push('🤖 Agent:\n' + truncated);
+                    return parts.join('\n\n');
+                }
+            }
+        }
+    } catch (e) {
+        console.log('[getFullLatestResponse] File-system extraction failed:', e.message);
+    }
+    
+    // --- Fallback: DOM extraction (may be stale if threads were switched) ---
+    const candidates = await resolveTargets(port);
     for (const target of candidates) {
         try {
             const client = await CDP({ target: target.webSocketDebuggerUrl });
             const { Runtime } = client;
             await Runtime.enable();
-
-            const boxResult = await Runtime.evaluate({
-                expression: CHAT_EXTRACT_EXPR,
-                awaitPromise: true,
+            
+            const expr = CHAT_EXTRACT_EXPR.replace(
+                "extractedText = msgs.join('\\n\\n');",
+                "extractedText = msgs.slice(-2).join('\\n\\n');"
+            );
+            
+            const res = await Runtime.evaluate({
+                expression: expr,
                 returnByValue: true
             });
-            const val = boxResult?.result?.value;
             await client.close();
             
-            if (val && val.length > 0) {
-                let fullStr = val;
-                let diffStr = fullStr;
-                
-                // Compare with previous state to only return NEW messages
-                if (globalLastChatState) {
-                    if (fullStr.includes(globalLastChatState)) {
-                        diffStr = fullStr.substring(fullStr.lastIndexOf(globalLastChatState) + globalLastChatState.length).trim();
-                    } else {
-                        let overlapFound = false;
-                        // Try finding progressively smaller suffixes from the end of globalLastChatState
-                        for (let size = Math.min(200, globalLastChatState.length); size >= 20; size -= 20) {
-                            const suffix = globalLastChatState.slice(-size);
-                            const lastIdx = fullStr.lastIndexOf(suffix);
-                            if (lastIdx !== -1) {
-                                diffStr = fullStr.substring(lastIdx + size).trim();
-                                overlapFound = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-                
-                if (fullStr.length > 0) {
-                    globalLastChatState = fullStr; // Save state for next call
-                }
-                
-                if (diffStr && diffStr.trim() !== '') {
-                    globalLastValidResponse = diffStr;
-                }
-                
-                return diffStr || "[No new messages]";
-            } else {
-                logs.push(`${target.title}: empty`);
+            if (res.result?.value && res.result.value.trim() !== '') {
+                return res.result.value;
             }
-        } catch(e) {
-            logs.push(`${target.title}: ${e.message}`);
-        }
+        } catch(e) {}
     }
-    throw new Error(`Failed to extract text. Details: ${logs.join(', ')}`);
-}
-
-/**
- * Get the full last agent response block (no diffing).
- * Used by /latest command so it always returns something useful.
- * Now it simply returns the cached last successful diff, avoiding grabbing user messages.
- */
-async function getFullLatestResponse(port) {
+    
+    // Fallback to cache if everything failed
     if (globalLastValidResponse) {
         return globalLastValidResponse;
     }
+    
     return "[No previous message stored yet. Run a prompt first.]";
 }
 
@@ -307,7 +458,13 @@ async function waitForAgentResponse(port, timeoutMs = 450000, onProgress = null)
         // Re-fetch targets on each iteration to avoid stale WebSocket connections
         let candidates;
         try {
-            candidates = await resolveTargets(port);
+            const raw = await resolveTargets(port);
+            // Manager has the active conversation — check it first
+            candidates = [...raw].sort((a, b) => {
+                if (a.title === 'Manager') return -1;
+                if (b.title === 'Manager') return 1;
+                return 0;
+            });
         } catch(e) {
             await new Promise(r => setTimeout(r, 3000));
             continue;
@@ -324,23 +481,12 @@ async function waitForAgentResponse(port, timeoutMs = 450000, onProgress = null)
                 await Runtime.enable();
                 const check = await Runtime.evaluate({
                     expression: `
+                        ${UI_LOCATORS_SCRIPT}
                         (function() {
-                            // Only treat stop icons inside the chat area as generation indicators
-                            const chatArea = document.querySelector('#conversation, #chat, #cascade');
-                            const stopIcon = chatArea ? chatArea.querySelector("svg.lucide-square, [data-tooltip-id*='cancel']") : null;
-                            const isGenerating = !!stopIcon;
-                            const editor = document.querySelector('[contenteditable="true"], textarea');
+                            const isGenerating = !!AG_UI.getStopButton();
+                            const editor = AG_UI.getChatInput();
                             const isInputDisabled = editor ? (editor.getAttribute('contenteditable') === 'false' || editor.disabled) : false;
-                            
-                            // Check for visible loading spinners, but exclude tiny persistent status spinners (h-3 w-3)
-                            const isSpinning = Array.from(document.querySelectorAll('.codicon-loading, .loading, [class*="animate-spin"], [class*="spinner"], [class*="loader"]')).some(el => {
-                                if (el.offsetParent === null) return false;
-                                // Exclude tiny status spinners (h-3 w-3) and opacity-reduced parents
-                                if (el.className.includes('h-3') && el.className.includes('w-3')) return false;
-                                const parent = el.parentElement;
-                                if (parent && (parent.className.includes('opacity-') || parent.className.includes('hidden'))) return false;
-                                return true;
-                            });
+                            const isSpinning = AG_UI.isLoading();
                             
                             // Check if AutoAccept is active and there is a button waiting to be clicked
                             const aaActive = !!window.__AA_BOT_OBSERVER_ACTIVE && !window.__AA_BOT_PAUSED;
@@ -355,7 +501,7 @@ async function waitForAgentResponse(port, timeoutMs = 450000, onProgress = null)
                             }
                             
                             const isIdle = !isGenerating && !isInputDisabled && !isSpinning && !hasPendingButton;
-                            const hasChat = !!document.querySelector('#conversation, #chat, #cascade, .chat-input, .interactive-input-editor');
+                            const hasChat = !!AG_UI.getVisibleChatContainer();
                             return { hasChat, isGenerating, isIdle, isSpinning, hasPendingButton };
                         })()
                     `,
@@ -400,9 +546,18 @@ async function waitForAgentResponse(port, timeoutMs = 450000, onProgress = null)
 
 async function sendViaCDP(text, port) {
     const candidates = await resolveTargets(port);
+    
+    // Prioritize the Manager target — its #antigravity input always belongs
+    // to the active conversation. Workspace targets' side-panel inputs may
+    // be stale from previously-viewed threads.
+    const sortedCandidates = [...candidates].sort((a, b) => {
+        if (a.title === 'Manager') return -1;
+        if (b.title === 'Manager') return 1;
+        return 0;
+    });
 
     const errors = [];
-    for (const target of candidates) {
+    for (const target of sortedCandidates) {
         let client;
         try {
             client = await CDP({ target: target.webSocketDebuggerUrl });
@@ -414,10 +569,17 @@ async function sendViaCDP(text, port) {
                     (async function() {
                         try {
                             const escapedText = ${JSON.stringify(text)};
-                            const editors = [...document.querySelectorAll('.interactive-input-editor textarea, #conversation textarea, #chat textarea, .chat-input textarea, [aria-label*="chat input" i] textarea, [contenteditable="true"]')]
+                            
+                            // Find the input inside #antigravity (the main agent panel input box).
+                            // This is the primary active conversation input in the Manager target.
+                            const agPanel = document.querySelector('#antigravity [contenteditable="true"]');
+                            
+                            // Fallback: any contenteditable not in xterm
+                            const allEditors = [...document.querySelectorAll('[contenteditable="true"]')]
                                 .filter(el => !el.className.includes('xterm'));
                             
-                            const editor = editors.at(-1);
+                            const editor = agPanel || allEditors.at(-1);
+                            
                             if (!editor) return { found: false, reason: "no_editor", editorCount: 0 };
 
                             editor.focus();
@@ -445,10 +607,12 @@ async function sendViaCDP(text, port) {
                             // Use setTimeout instead of requestAnimationFrame so it doesn't hang when minimized!
                             await new Promise(r => setTimeout(r, 150));
 
-                            const submit = document.querySelector("svg.lucide-arrow-right, svg[class*='arrow-right'], svg[class*='send']")?.closest("button");
+                            // Find the submit button near the editor (within same panel)
+                            const panelContainer = editor.closest('#antigravity') || editor.closest('#conversation') || document;
+                            const submit = panelContainer.querySelector("svg.lucide-arrow-right, svg[class*='arrow-right'], svg[class*='send']")?.closest("button");
                             if (submit && !submit.disabled) {
                                 setTimeout(() => submit.click(), 10);
-                                return { found: true, method: 'button' };
+                                return { found: true, method: 'button', target: '${target.title?.substring(0, 30) || 'unknown'}' };
                             }
 
                             setTimeout(() => {
@@ -456,7 +620,7 @@ async function sendViaCDP(text, port) {
                                     editor.dispatchEvent(new KeyboardEvent(type, { bubbles: true, key: "Enter", code: "Enter", keyCode: 13, which: 13 }));
                                 });
                             }, 10);
-                            return { found: true, method: 'keyboard' };
+                            return { found: true, method: 'keyboard', target: '${target.title?.substring(0, 30) || 'unknown'}' };
                         } catch(err) {
                             return { found: false, reason: err.message };
                         }
@@ -505,25 +669,13 @@ async function triggerNewChat(port) {
             await Runtime.enable();
             const res = await Runtime.evaluate({
                 expression: `
+                    ${UI_LOCATORS_SCRIPT}
                     (() => {
-                        // 1. Exact SVG Path match for the + icon (New Chat button)
-                        const svgPath = document.querySelector('path[d="M12 4.5v15m7.5-7.5h-15"]');
-                        if (svgPath) {
-                            // Walk up to find the clickable parent (a, button, or div)
-                            let clickTarget = svgPath.closest('a, button, [role="button"]') || svgPath.closest('svg')?.parentElement;
-                            if (clickTarget && typeof clickTarget.click === 'function') {
-                                clickTarget.click();
-                                return { clicked: true, method: 'svg_path', tag: clickTarget.tagName, aria: clickTarget.getAttribute('aria-label') || '' };
-                            }
-                        }
-                        
-                        // 2. aria-label based selectors
-                        const btn = document.querySelector('[aria-label*="New Chat" i], [title*="New Chat" i], [aria-label*="Yeni Sohbet" i], [class*="new-chat"], [aria-label*="New Task" i], [title*="New Task" i]');
+                        const btn = AG_UI.getNewChatButton();
                         if (btn && typeof btn.click === 'function') {
                             btn.click();
-                            return { clicked: true, method: 'aria_label', tag: btn.tagName, aria: btn.getAttribute('aria-label') || '' };
+                            return { clicked: true, tag: btn.tagName };
                         }
-                        
                         return { clicked: false };
                     })()
                 `, returnByValue: true
@@ -544,7 +696,13 @@ async function triggerNewChat(port) {
 
 
 async function triggerModelMenu(port) {
-    const candidates = await resolveTargets(port, false);
+    const raw = await resolveTargets(port, false);
+    // Manager has the active conversation's model selector
+    const candidates = [...raw].sort((a, b) => {
+        if (a.title === 'Manager') return -1;
+        if (b.title === 'Manager') return 1;
+        return 0;
+    });
 
     for (const target of candidates) {
         try {
@@ -553,8 +711,9 @@ async function triggerModelMenu(port) {
             await Runtime.enable();
             const res = await Runtime.evaluate({
                 expression: `
+                    ${UI_LOCATORS_SCRIPT}
                     (() => {
-                        const btn = document.querySelector('[aria-label*="Select model" i], [title*="Select model" i]');
+                        const btn = AG_UI.getModelSelectorButton();
                         if (btn) { btn.click(); return true; }
                         return false;
                     })()
@@ -567,8 +726,191 @@ async function triggerModelMenu(port) {
     return false;
 }
 
+async function listAgentThreads(port) {
+    const candidates = await resolveTargets(port, false);
+    for (const target of candidates) {
+        try {
+            const client = await CDP({ target: target.webSocketDebuggerUrl });
+            const { Runtime } = client;
+            await Runtime.enable();
+            const res = await Runtime.evaluate({
+                expression: `
+                    ${UI_LOCATORS_SCRIPT}
+                    (() => {
+                        const workspaces = [];
+                        const cards = AG_UI.getWorkspaceCards();
+                        cards.forEach(card => {
+                            const wsNameEl = card.querySelector('span.truncate');
+                            if (!wsNameEl) return;
+                            const wsName = wsNameEl.textContent.trim();
+                            
+                            const threads = [];
+                            const sibling = card.nextElementSibling;
+                            if (sibling) {
+                                const pills = AG_UI.getChatThreadPills(sibling);
+                                pills.forEach(pill => {
+                                    const name = pill.textContent.trim();
+                                    const id = pill.getAttribute('data-testid').replace('convo-pill-', '');
+                                    const row = pill.closest('[role="button"]');
+                                    let time = '';
+                                    if (row) {
+                                        const timeEl = row.querySelector('.text-xs.opacity-50');
+                                        if (timeEl) time = timeEl.textContent.trim();
+                                    }
+                                    threads.push({ name, id, time });
+                                });
+                            }
+                            if (threads.length > 0) {
+                                workspaces.push({ workspace: wsName, threads });
+                            }
+                        });
+                        return workspaces;
+                    })()
+                `,
+                returnByValue: true
+            });
+            await client.close();
+            if (res.result?.value && res.result.value.length > 0) {
+                return res.result.value;
+            }
+        } catch(e) {}
+    }
+    return [];
+}
+
+async function switchAgentThread(port, threadId) {
+    const candidates = await resolveTargets(port, false);
+    for (const target of candidates) {
+        try {
+            const client = await CDP({ target: target.webSocketDebuggerUrl });
+            const { Runtime } = client;
+            await Runtime.enable();
+            const res = await Runtime.evaluate({
+                expression: `
+                    (() => {
+                        const pill = document.querySelector('[data-testid="convo-pill-' + ${JSON.stringify(threadId)} + '"]');
+                        if (pill) {
+                            const btn = pill.closest('[role="button"]');
+                            if (btn && typeof btn.click === 'function') {
+                                btn.click();
+                                return true;
+                            }
+                        }
+                        return false;
+                    })()
+                `,
+                returnByValue: true
+            });
+            await client.close();
+            if (res.result?.value) return true;
+        } catch(e) {}
+    }
+    return false;
+}
+
+async function getActiveThreadId(port) {
+    const candidates = await resolveTargets(port, false);
+    for (const target of candidates) {
+        try {
+            const client = await CDP({ target: target.webSocketDebuggerUrl });
+            const { Runtime } = client;
+            await Runtime.enable();
+            const res = await Runtime.evaluate({
+                expression: `
+                    (() => {
+                        const all = document.querySelectorAll('[data-testid^="convo-pill-"]');
+                        for (let el of all) {
+                            const row = el.closest('[role="button"]');
+                            if (row && row.classList.contains('bg-list-hover')) {
+                                return el.getAttribute('data-testid').replace('convo-pill-', '');
+                            }
+                        }
+                        return null;
+                    })()
+                `,
+                returnByValue: true
+            });
+            await client.close();
+            if (res.result?.value) return res.result.value;
+        } catch(e) {}
+    }
+    return null;
+}
+async function isAgentWorking(port) {
+    const raw = await resolveTargets(port, false);
+    // Manager has the active conversation — check it first
+    const candidates = [...raw].sort((a, b) => {
+        if (a.title === 'Manager') return -1;
+        if (b.title === 'Manager') return 1;
+        return 0;
+    });
+    for (const target of candidates) {
+        try {
+            const client = await CDP({ target: target.webSocketDebuggerUrl });
+            const { Runtime } = client;
+            await Runtime.enable();
+            const check = await Runtime.evaluate({
+                expression: `
+                    ${UI_LOCATORS_SCRIPT}
+                    (function() {
+                        const isGenerating = !!AG_UI.getStopButton();
+                        const editor = AG_UI.getChatInput();
+                        const isInputDisabled = editor ? (editor.getAttribute('contenteditable') === 'false' || editor.disabled) : false;
+                        const isSpinning = AG_UI.isLoading();
+                        
+                        const aaActive = !!window.__AA_BOT_OBSERVER_ACTIVE && !window.__AA_BOT_PAUSED;
+                        let hasPendingButton = false;
+                        if (aaActive) {
+                            const texts = ['run', 'accept', 'allow', 'continue', 'retry', 'çalıştır', 'kabul et', 'izin ver', 'devam et', 'yeniden dene'];
+                            const btns = Array.from(document.querySelectorAll('button')).filter(b => b.offsetParent !== null);
+                            hasPendingButton = btns.some(b => {
+                                const t = (b.textContent||'').trim().toLowerCase();
+                                return texts.some(x => t === x || t.startsWith(x + ' ') || (t.startsWith(x) && t.length <= x.length + 8));
+                            });
+                        }
+                        
+                        return isGenerating || isInputDisabled || isSpinning || hasPendingButton;
+                    })()
+                `,
+                returnByValue: true
+            });
+            await client.close();
+            if (check && check.result && check.result.value !== undefined) {
+                return check.result.value;
+            }
+        } catch(e) {}
+    }
+    return false;
+}
+
+async function getCurrentModel(port) {
+    const candidates = await resolveTargets(port, false);
+    for (const target of candidates) {
+        try {
+            const client = await CDP({ target: target.webSocketDebuggerUrl });
+            const { Runtime } = client;
+            await Runtime.enable();
+            const check = await Runtime.evaluate({
+                expression: `
+                    ${UI_LOCATORS_SCRIPT}
+                    (function() {
+                        const btn = AG_UI.getModelSelectorButton();
+                        if (btn) {
+                            return btn.textContent.trim();
+                        }
+                        return null;
+                    })()
+                `, returnByValue: true
+            });
+            await client.close();
+            if (check?.result?.value) return check.result.value;
+        } catch(e) {}
+    }
+    return null;
+}
+
 module.exports = {
-    getLatestAgentResponse,
+    isAgentWorking,
     getFullLatestResponse,
     snapshotChatState,
     captureAgentScreenshot,
@@ -579,6 +921,7 @@ module.exports = {
     triggerModelMenu,
     getAvailableModels,
     selectModel,
+    getCurrentModel,
     stopAgent,
     getQuota,
     resolveTargets,
@@ -586,7 +929,10 @@ module.exports = {
     setPreferredWindow,
     getPreferredWindow,
     getCachedWindows,
-    closeWindow
+    closeWindow,
+    listAgentThreads,
+    switchAgentThread,
+    getActiveThreadId
 };
 
 async function captureFullIDEScreenshot(port) {
@@ -612,7 +958,13 @@ async function captureFullIDEScreenshot(port) {
 }
 
 async function getAvailableModels(port) {
-    const candidates = await resolveTargets(port, false);
+    const raw = await resolveTargets(port, false);
+    // Manager has the active conversation's model selector
+    const candidates = [...raw].sort((a, b) => {
+        if (a.title === 'Manager') return -1;
+        if (b.title === 'Manager') return 1;
+        return 0;
+    });
 
     for (const target of candidates) {
         try {
@@ -623,13 +975,10 @@ async function getAvailableModels(port) {
             // Önce model menüsünü aç
             await Runtime.evaluate({
                 expression: `
+                    ${UI_LOCATORS_SCRIPT}
                     (() => {
-                        const btn = document.querySelector('[aria-label*="Select model" i], [title*="Select model" i], [aria-label*="model" i]');
+                        const btn = AG_UI.getModelSelectorButton();
                         if (btn) { btn.click(); return true; }
-                        // Fallback: model adı gösteren butonu bul
-                        const allBtns = Array.from(document.querySelectorAll('button'));
-                        const modelBtn = allBtns.find(b => b.textContent.match(/gemini|claude|gpt|flash|pro|opus|sonnet/i));
-                        if (modelBtn) { modelBtn.click(); return true; }
                         return false;
                     })()
                 `, returnByValue: true
@@ -641,24 +990,14 @@ async function getAvailableModels(port) {
             // Model listesini oku
             const res = await Runtime.evaluate({
                 expression: `
+                    ${UI_LOCATORS_SCRIPT}
                     (() => {
-                        // Dropdown/listbox öğelerini bul
-                        const items = document.querySelectorAll('[role="option"], [role="menuitem"], [role="listitem"], .model-item, [class*="model-option"], [class*="dropdown"] li, [class*="menu"] [class*="item"]');
                         const models = [];
+                        const items = AG_UI.getModelOptions();
                         items.forEach(el => {
-                            const text = (el.textContent || '').trim();
-                            if (text && text.length > 2 && text.length < 80 && !text.includes('\\n')) {
-                                models.push(text);
-                            }
-                        });
-                        if (models.length > 0) return models;
-                        
-                        // Fallback: tüm görünür liste öğelerini tara
-                        const allLis = document.querySelectorAll('li, [role="option"]');
-                        allLis.forEach(el => {
-                            if (el.offsetParent && el.textContent.trim().length > 2) {
+                            if (el.offsetParent) {
                                 const t = el.textContent.trim().split('\\n')[0].trim();
-                                if (t.length < 80) models.push(t);
+                                if (t.length > 2 && t.length < 80) models.push(t);
                             }
                         });
                         return models;
@@ -674,7 +1013,13 @@ async function getAvailableModels(port) {
 }
 
 async function selectModel(port, modelName) {
-    const candidates = await resolveTargets(port, false);
+    const raw = await resolveTargets(port, false);
+    // Manager has the active conversation's model selector
+    const candidates = [...raw].sort((a, b) => {
+        if (a.title === 'Manager') return -1;
+        if (b.title === 'Manager') return 1;
+        return 0;
+    });
 
     for (const target of candidates) {
         try {
@@ -685,32 +1030,16 @@ async function selectModel(port, modelName) {
             // Step 1: Check if dropdown is already open, if not click the model selector button
             const openRes = await Runtime.evaluate({
                 expression: `
+                    ${UI_LOCATORS_SCRIPT}
                     (() => {
                         // Check if model dropdown is already open by looking for model option buttons
-                        const existingOptions = Array.from(document.querySelectorAll('button')).filter(b => 
-                            b.className.includes('px-2 py-1') && 
-                            b.className.includes('w-full') &&
-                            b.className.includes('cursor-pointer')
-                        );
+                        const existingOptions = AG_UI.getModelOptions().filter(el => el.offsetParent !== null);
                         if (existingOptions.length > 3) return { alreadyOpen: true };
                         
                         // Click the model selector button to open dropdown
-                        const selectorBtn = document.querySelector('[aria-label*="Select model" i]');
+                        const selectorBtn = AG_UI.getModelSelectorButton();
                         if (selectorBtn) {
                             selectorBtn.click();
-                            return { clicked: true };
-                        }
-                        
-                        // Fallback: find button showing current model name
-                        const allBtns = Array.from(document.querySelectorAll('button'));
-                        const modelBtn = allBtns.find(b => {
-                            const t = b.textContent.toLowerCase();
-                            return (t.includes('gemini') || t.includes('claude') || t.includes('gpt')) && 
-                                   b.className.includes('cursor-pointer') &&
-                                   b.getAttribute('aria-label')?.includes('Select model');
-                        });
-                        if (modelBtn) {
-                            modelBtn.click();
                             return { clicked: true };
                         }
                         return { clicked: false };
@@ -730,17 +1059,10 @@ async function selectModel(port, modelName) {
             // Step 3: Find and click the matching model in the dropdown
             const selectRes = await Runtime.evaluate({
                 expression: `
+                    ${UI_LOCATORS_SCRIPT}
                     (() => {
                         const targetModel = ${JSON.stringify(modelName)}.toLowerCase();
-                        const allBtns = Array.from(document.querySelectorAll('button'));
-                        
-                        // Find model option buttons in the dropdown
-                        const modelOptions = allBtns.filter(b => 
-                            b.className.includes('px-2') && 
-                            b.className.includes('w-full') &&
-                            b.className.includes('cursor-pointer') &&
-                            b.className.includes('items-center')
-                        );
+                        const modelOptions = AG_UI.getModelOptions().filter(el => el.offsetParent !== null);
                         
                         // Try exact match first
                         let match = modelOptions.find(b => {
@@ -793,22 +1115,11 @@ async function stopAgent(port) {
 
             const res = await Runtime.evaluate({
                 expression: `
+                    ${UI_LOCATORS_SCRIPT}
                     (() => {
-                        // Stop/Cancel butonunu bul
-                        const stopIcon = document.querySelector("svg.lucide-square, [data-tooltip-id*='cancel'], [aria-label*='Stop'], [title*='Stop'], [aria-label*='Cancel']");
-                        if (stopIcon) {
-                            const btn = stopIcon.closest('button') || stopIcon;
+                        const btn = AG_UI.getStopButton();
+                        if (btn) {
                             btn.click();
-                            return { stopped: true };
-                        }
-                        // Fallback: square icon olan butonu bul
-                        const allBtns = Array.from(document.querySelectorAll('button'));
-                        const stopBtn = allBtns.find(b => {
-                            const svg = b.querySelector('svg');
-                            return svg && (svg.classList.contains('lucide-square') || b.innerHTML.includes('square'));
-                        });
-                        if (stopBtn) {
-                            stopBtn.click();
                             return { stopped: true };
                         }
                         return { stopped: false };

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,11 @@ const os = require('os');
 const { exec } = require('child_process');
 const { loadLocale, t, getLang } = require('./i18n');
 const { config, isIDERunning, killIDE, cleanLockFile, launchIDE, trustWorkspaceViaCDP, PLATFORM } = require('./platform');
-const { getLatestAgentResponse, getFullLatestResponse, snapshotChatState, captureAgentScreenshot, captureFullIDEScreenshot, waitForAgentResponse, sendViaCDP, triggerNewChat, triggerModelMenu, getAvailableModels, selectModel, stopAgent, getQuota, listWindows, setPreferredWindow, getPreferredWindow, getCachedWindows, closeWindow } = require('./cdp_controller');
+const { isAgentWorking, getFullLatestResponse, snapshotChatState, captureAgentScreenshot, captureFullIDEScreenshot, waitForAgentResponse, sendViaCDP, triggerNewChat, triggerModelMenu, getAvailableModels, selectModel, getCurrentModel, stopAgent, getQuota, listWindows, setPreferredWindow, getPreferredWindow, getCachedWindows, closeWindow, listAgentThreads, switchAgentThread, getActiveThreadId } = require('./cdp_controller');
 const autoaccept = require('./autoaccept');
+
+let cachedAgentThreads = [];
+let cachedArtifacts = [];
 
 // Load configured language
 const lang = process.env.LANGUAGE || 'en';
@@ -19,27 +22,55 @@ if (!ALLOWED_CHAT_ID) {
     console.error('\n❌ SECURITY ERROR: ALLOWED_CHAT_ID is required.\n');
     console.error('Set ALLOWED_CHAT_ID in your .env file to your Telegram chat ID.');
     console.error('Send /start to your bot to discover your chat ID.\n');
-    process.exit(1);
+    // process.exit(1);
 }
 
 const bot = new Telegraf(process.env.BOT_TOKEN, { handlerTimeout: 900000 }); // 15 minutes timeout to allow long /ask requests
 const CDP_PORT = process.env.DEBUGGING_PORT || 9333;
 
+function markdownToTelegramHtml(text) {
+    let html = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    html = html.replace(/^(#{1,6})\s+(.+)$/gm, '<b>$2</b>');
+    html = html.replace(/\*\*([^\*]+)\*\*/g, '<b>$1</b>');
+    html = html.replace(/(?<![A-Za-z0-9])\*([^\*]+)\*(?![A-Za-z0-9])/g, '<i>$1</i>');
+    html = html.replace(/(?<![A-Za-z0-9])_([^_]+)_(?![A-Za-z0-9])/g, '<i>$1</i>');
+    html = html.replace(/```([a-z0-9]*)\n([\s\S]*?)```/g, (match, lang, code) => {
+        if (lang) return `<pre><code class="language-${lang}">${code}</code></pre>`;
+        return `<pre>${code}</pre>`;
+    });
+    html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+    html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+    html = html.replace(/\[x\]/ig, '✅');
+    html = html.replace(/\[ \]/g, '⬜');
+    html = html.replace(/\[\/\]/g, '🔄');
+    return html;
+}
+
 // Helper: Send long messages safely within Telegram's 4096 char limit
 async function sendLongMessage(ctx, text, prefix = '') {
-    const MAX_LEN = 4000;
-    const fullText = prefix ? `${prefix}\n\n${text}` : text;
+    const MAX_LEN = 3500;
     
-    // Retry helper for transient network errors
+    // Parse text to HTML and preserve prefix formatting
+    const htmlText = prefix ? `<b>${prefix}</b>\n\n${markdownToTelegramHtml(text)}` : markdownToTelegramHtml(text);
+    
     async function replyWithRetry(content, retries = 3) {
         for (let attempt = 1; attempt <= retries; attempt++) {
             try {
-                await ctx.reply(content);
+                await ctx.reply(content, { parse_mode: 'HTML' });
                 return;
             } catch (err) {
                 console.error(`sendLongMessage attempt ${attempt}/${retries} failed:`, err.message);
-                if (attempt < retries && (err.code === 'EAI_AGAIN' || err.code === 'ETIMEDOUT' || err.code === 'ECONNRESET')) {
+                if (attempt < retries && !err.message.includes("can't parse entities")) {
                     await new Promise(r => setTimeout(r, 2000 * attempt));
+                } else if (err.message.includes("can't parse entities")) {
+                    // Fallback to sending raw text if HTML parsing completely fails
+                    try {
+                        const plain = content.replace(/<[^>]*>/g, '').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+                        await ctx.reply(plain);
+                        return;
+                    } catch (fallbackErr) {
+                        throw fallbackErr;
+                    }
                 } else {
                     throw err;
                 }
@@ -48,32 +79,36 @@ async function sendLongMessage(ctx, text, prefix = '') {
     }
 
     try {
-        if (fullText.length <= MAX_LEN) {
-            await replyWithRetry(fullText);
-        } else {
-            const chunks = [];
-            for (let i = 0; i < fullText.length; i += MAX_LEN) {
-                chunks.push(fullText.substring(i, i + MAX_LEN));
+        const lines = htmlText.split('\n');
+        let currentChunk = '';
+        let inPre = false;
+        let preLang = '';
+
+        for (const line of lines) {
+            const preMatch = line.match(/<pre>(?:<code class="language-([^"]+)">)?/);
+            if (preMatch) {
+                inPre = true;
+                preLang = preMatch[1] || '';
             }
-            for (let i = 0; i < chunks.length; i++) {
-                const suffix = chunks.length > 1 ? `\n\n(${i + 1}/${chunks.length})` : '';
-                await replyWithRetry(chunks[i] + suffix);
+            if (line.includes('</pre>')) {
+                inPre = false;
             }
+            
+            if (currentChunk.length + line.length > MAX_LEN) {
+                if (inPre) {
+                    currentChunk += preLang ? '</code></pre>' : '</pre>';
+                }
+                await replyWithRetry(currentChunk);
+                currentChunk = inPre ? (preLang ? `<pre><code class="language-${preLang}">\n` : '<pre>\n') : '';
+            }
+            currentChunk += line + '\n';
         }
-        console.log(`sendLongMessage: Sent ${fullText.length} chars successfully`);
+        if (currentChunk.trim().length > 0) {
+            await replyWithRetry(currentChunk);
+        }
+        console.log(`sendLongMessage: Sent successfully`);
     } catch (err) {
-        console.error('sendLongMessage error:', err.message);
-        // On format error, retry as plain text
-        try {
-            const plain = fullText.replace(/[*_`\[\]]/g, '');
-            if (plain.length <= MAX_LEN) {
-                await replyWithRetry(plain);
-            } else {
-                await replyWithRetry(plain.substring(0, MAX_LEN) + '\n\n' + t('response_too_long'));
-            }
-        } catch (e2) {
-            console.error('sendLongMessage final error:', e2.message);
-        }
+        console.error('sendLongMessage final error:', err.message);
     }
 }
 
@@ -100,6 +135,11 @@ function createProgressHandler(ctx) {
 }
 
 function checkAuth(ctx, next) {
+    if (!ALLOWED_CHAT_ID) {
+        console.log(`\n🔔 NEW CHAT ID DETECTED: ${ctx.chat.id}`);
+        console.log(`Please add ALLOWED_CHAT_ID=${ctx.chat.id} to your .env file and restart.\n`);
+        return ctx.reply(`Welcome! Your Chat ID is: ${ctx.chat.id}\nPlease add it to the .env file as ALLOWED_CHAT_ID and restart the bot.`);
+    }
     if (ctx.chat.id.toString() !== ALLOWED_CHAT_ID) {
         return ctx.reply(t('auth.unauthorized'));
     }
@@ -126,6 +166,9 @@ ${t('help.status_text')}
 
 ${t('help.ide_title')}
 ${t('help.ide_text')}
+
+${t('help.chat_title')}
+${t('help.chat_text')}
     `.trim();
     ctx.reply(helpMessage, { parse_mode: 'HTML' });
 });
@@ -180,21 +223,75 @@ bot.command('status', async (ctx) => {
     msg += ideCheck ? t('status.ide_running') + '\n' : t('status.ide_stopped') + '\n';
     
     try {
-        await getLatestAgentResponse(CDP_PORT);
+        await getActiveThreadId(CDP_PORT);
         msg += t('status.cdp_active') + '\n';
     } catch {
         msg += t('status.cdp_inactive') + '\n';
     }
     
     msg += t('status.bot_running') + '\n';
+    
+    try {
+        const activeId = await getActiveThreadId(CDP_PORT);
+        if (activeId) {
+            const workspaces = await listAgentThreads(CDP_PORT);
+            let activeWorkspace = null;
+            let activeThread = null;
+            
+            for (const ws of workspaces) {
+                const found = ws.threads.find(t => t.id === activeId);
+                if (found) {
+                    activeWorkspace = ws.workspace;
+                    activeThread = found.name;
+                    break;
+                }
+            }
+            
+            if (activeWorkspace && activeThread) {
+                msg += `\n💬 <b>Chat:</b>\n`;
+                msg += `- Workspace: ${activeWorkspace}\n`;
+                msg += `- Thread: ${activeThread}\n`;
+                const currentModel = await getCurrentModel(CDP_PORT);
+                if (currentModel) msg += `- Model: ${currentModel}\n`;
+                const isWorking = await isAgentWorking(CDP_PORT);
+                msg += `- Status: ${isWorking ? 'Working...' : 'Idle'}\n`;
+            }
+        }
+    } catch (e) {
+        // silently fail if we can't get chat info
+    }
+
     msg += '\n<b>Auto-Accept:</b> ' + (autoaccept.isEnabled ? '✅ ON' : '❌ OFF') + '\n';
 
     ctx.reply(msg, { parse_mode: 'HTML' });
 });
 
+/**
+ * Appends thread info and agent status footer to response text.
+ */
+async function appendThreadFooter(text) {
+    try {
+        const activeId = await getActiveThreadId(CDP_PORT);
+        if (activeId) {
+            const workspaces = await listAgentThreads(CDP_PORT);
+            let threadName = null;
+            let wsName = null;
+            for (const ws of workspaces) {
+                const found = ws.threads.find(t => t.id === activeId);
+                if (found) { wsName = ws.workspace; threadName = found.name; break; }
+            }
+            const isWorking = await isAgentWorking(CDP_PORT);
+            const statusLine = isWorking ? 'Working...' : 'Idle';
+            text += '\n\n' + `📁 ${wsName || 'Unknown'}` + (threadName ? ` / ${threadName}` : '') + `\nAgent Status: ${statusLine}`;
+        }
+    } catch (_) {}
+    return text;
+}
+
 bot.command('latest', async (ctx) => {
     try {
-        const text = await getLatestAgentResponse(CDP_PORT);
+        let text = await getFullLatestResponse(CDP_PORT);
+        text = await appendThreadFooter(text);
         await sendLongMessage(ctx, text, t('latest.title'));
     } catch (err) {
         ctx.reply(t('latest.error', { error: err.message }));
@@ -243,14 +340,10 @@ bot.command('ask', (ctx) => {
             
             const isDone = await waitForAgentResponse(CDP_PORT, 450000, createProgressHandler(ctx));
             if (isDone) {
-                let text = await getLatestAgentResponse(CDP_PORT);
+                let text = await getFullLatestResponse(CDP_PORT);
                 text = stripQueryFromResponse(text, query);
-                // Fallback: if diff is empty, get the full last response
-                if (!text || text === '[No new messages]') {
-                    text = await getFullLatestResponse(CDP_PORT);
-                    text = stripQueryFromResponse(text, query);
-                }
                 if (!text) text = t('ask.done_empty');
+                text = await appendThreadFooter(text);
                 await sendLongMessage(ctx, text, t('ask.done'));
             } else {
                 await ctx.reply(t('ask.timeout'));
@@ -306,6 +399,168 @@ bot.command('new', async (ctx) => {
     } catch(e) {
         console.log('[/new] Error:', e.message);
         ctx.reply(t('new_chat.error', { error: e.message }));
+    }
+});
+
+bot.command('agents', async (ctx) => {
+    const parts = ctx.message.text.split(' ');
+    const num = parseInt(parts[1], 10);
+    
+    if (!isNaN(num)) {
+        if (num > 0 && num <= cachedAgentThreads.length) {
+            const thread = cachedAgentThreads[num - 1];
+            ctx.reply(t('agents.switched', { name: thread.name }) || `✅ Switched to thread: ${thread.name}`, { parse_mode: 'HTML' });
+            const success = await switchAgentThread(CDP_PORT, thread.id);
+            if (!success) {
+                ctx.reply(t('agents.not_found') || '❌ Thread could not be selected.');
+            }
+        } else {
+            ctx.reply(t('agents.invalid_number') || '❌ Invalid thread number.');
+        }
+        return;
+    }
+    
+    try {
+        const workspaces = await listAgentThreads(CDP_PORT);
+        if (workspaces.length === 0) {
+            return ctx.reply(t('agents.no_recent') || 'ℹ️ No recent active threads found.');
+        }
+        
+        cachedAgentThreads = [];
+        let msg = t('agents.list_title') || '📂 <b>Recent Chat Threads:</b>\\n\\n';
+        let index = 1;
+        
+        for (const ws of workspaces) {
+            const recentThreads = ws.threads.filter(th => {
+                const time = th.time ? th.time.toLowerCase() : '';
+                if (!time) return false;
+                if (time === 'now' || time.includes('m') || time.includes('h') || time === '1d' || time === '2d') {
+                    if (time.includes('mo')) return false;
+                    return true;
+                }
+                return false;
+            });
+            
+            if (recentThreads.length > 0) {
+                msg += `<b>📁 ${ws.workspace}</b>\n`;
+                for (const th of recentThreads) {
+                    cachedAgentThreads.push(th);
+                    msg += `  /agents_${index} - ${th.name} <i>(${th.time})</i>\n`;
+                    index++;
+                }
+                msg += '\n';
+            }
+        }
+        
+        if (cachedAgentThreads.length === 0) {
+            return ctx.reply(t('agents.no_recent') || 'ℹ️ No recent active threads found.');
+        }
+        
+        ctx.reply(msg, { parse_mode: 'HTML' });
+    } catch (e) {
+        ctx.reply((t('agents.error') || '❌ Error: ') + e.message);
+    }
+});
+
+bot.hears(/^\/agents_(\d+)$/, async (ctx) => {
+    const num = parseInt(ctx.match[1], 10);
+    if (num > 0 && num <= cachedAgentThreads.length) {
+        const thread = cachedAgentThreads[num - 1];
+        ctx.reply(t('agents.switched', { name: thread.name }) || `✅ Switched to thread: ${thread.name}`, { parse_mode: 'HTML' });
+        const success = await switchAgentThread(CDP_PORT, thread.id);
+        if (!success) {
+            ctx.reply(t('agents.not_found') || '❌ Thread could not be selected.');
+        }
+    } else {
+        ctx.reply(t('agents.invalid_number') || '❌ Invalid thread number.');
+    }
+});
+
+bot.command('artifacts', async (ctx) => {
+    try {
+        const activeId = await getActiveThreadId(CDP_PORT);
+        if (!activeId) {
+            return ctx.reply(t('artifacts.no_active_thread') || '⚠️ No active thread found. Please select a thread in the IDE first.');
+        }
+
+        const artifactsDir = path.join(os.homedir(), '.gemini', 'antigravity', 'brain', activeId);
+        if (!fs.existsSync(artifactsDir)) {
+            return ctx.reply(t('artifacts.no_artifacts') || 'ℹ️ No artifacts found for the current thread.');
+        }
+
+        const items = fs.readdirSync(artifactsDir, { withFileTypes: true });
+        cachedArtifacts = [];
+        
+        for (const item of items) {
+            if (item.isDirectory()) continue;
+            const name = item.name;
+            if (name.includes('.metadata.json') || name.includes('.resolved') || name.startsWith('.sys')) {
+                continue;
+            }
+            if (name.endsWith('.md') || name.endsWith('.png') || name.endsWith('.jpg') || name.endsWith('.jpeg') || name.endsWith('.webp') || name.endsWith('.mp4') || name.endsWith('.mov')) {
+                cachedArtifacts.push({ name, path: path.join(artifactsDir, name) });
+            }
+        }
+
+        if (cachedArtifacts.length === 0) {
+            return ctx.reply(t('artifacts.no_artifacts') || 'ℹ️ No artifacts found for the current thread.');
+        }
+
+        let msg = t('artifacts.list_title') || '📎 <b>Artifacts for Current Thread:</b>\\n\\n';
+        for (let i = 0; i < cachedArtifacts.length; i++) {
+            const filename = cachedArtifacts[i].name;
+            let displayName = filename;
+            if (filename.startsWith('media__')) {
+                const match = filename.match(/media__(\d+)\.\w+/);
+                if (match) {
+                    const date = new Date(parseInt(match[1], 10));
+                    const today = new Date();
+                    const yesterday = new Date(today);
+                    yesterday.setDate(yesterday.getDate() - 1);
+                    
+                    let dateStr = '';
+                    if (date.toDateString() === today.toDateString()) dateStr = 'Today';
+                    else if (date.toDateString() === yesterday.toDateString()) dateStr = 'Yesterday';
+                    else dateStr = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+                    
+                    const timeStr = date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+                    displayName = `Media (${dateStr} ${timeStr})`;
+                }
+            } else {
+                displayName = filename.replace(/\.[^/.]+$/, "").replace(/_/g, ' ').split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+            }
+            msg += `/artifact_${i + 1} - ${displayName}\n`;
+        }
+        
+        ctx.reply(msg, { parse_mode: 'HTML' });
+    } catch (e) {
+        ctx.reply((t('artifacts.error') || '❌ Error reading artifact: ') + e.message);
+    }
+});
+
+bot.hears(/^\/artifact_(\d+)$/, async (ctx) => {
+    const num = parseInt(ctx.match[1], 10);
+    if (num > 0 && num <= cachedArtifacts.length) {
+        const artifact = cachedArtifacts[num - 1];
+        ctx.reply((t('artifacts.sending', { name: artifact.name }) || `📤 Sending artifact: <b>${artifact.name}</b>...`), { parse_mode: 'HTML' });
+        
+        const ext = path.extname(artifact.name).toLowerCase();
+        try {
+            if (ext === '.png' || ext === '.jpg' || ext === '.jpeg' || ext === '.webp') {
+                await ctx.replyWithPhoto({ source: artifact.path });
+            } else if (ext === '.mp4' || ext === '.mov') {
+                await ctx.replyWithVideo({ source: artifact.path });
+            } else if (ext === '.md') {
+                const content = fs.readFileSync(artifact.path, 'utf8');
+                await sendLongMessage(ctx, content);
+            } else {
+                await ctx.replyWithDocument({ source: artifact.path });
+            }
+        } catch (e) {
+            ctx.reply((t('artifacts.error') || '❌ Error: ') + e.message);
+        }
+    } else {
+        ctx.reply(t('artifacts.invalid_number') || '❌ Invalid artifact number.');
     }
 });
 
@@ -822,6 +1077,8 @@ function getMenuCommands() {
         { command: 'start_ide', description: t('menu.start_ide_desc') },
         { command: 'close', description: t('menu.close_desc') },
         { command: 'new', description: t('menu.new_desc') },
+        { command: 'agents', description: t('menu.agents_desc') },
+        { command: 'artifacts', description: t('menu.artifacts_desc') },
         { command: 'model', description: t('menu.model_desc') },
         { command: 'workspace', description: t('menu.workspace_desc') },
         { command: 'window', description: t('menu.window_desc') || 'Select IDE window' },
@@ -944,14 +1201,10 @@ bot.on('text', (ctx) => {
             
             const isDone = await waitForAgentResponse(CDP_PORT, 450000, createProgressHandler(ctx));
             if (isDone) {
-                let text = await getLatestAgentResponse(CDP_PORT);
+                let text = await getFullLatestResponse(CDP_PORT);
                 text = stripQueryFromResponse(text, query);
-                // Fallback: if diff is empty, get the full last response
-                if (!text || text === '[No new messages]') {
-                    text = await getFullLatestResponse(CDP_PORT);
-                    text = stripQueryFromResponse(text, query);
-                }
                 if (!text) text = t('ask.done_empty');
+                text = await appendThreadFooter(text);
                 await sendLongMessage(ctx, text, t('ask.done'));
             } else {
                 await ctx.reply(t('ask.timeout'));
@@ -1009,18 +1262,13 @@ bot.on(['photo', 'document'], (ctx) => {
             
             const isDone = await waitForAgentResponse(CDP_PORT, 450000, createProgressHandler(ctx));
             if (isDone) {
-                let text = await getLatestAgentResponse(CDP_PORT);
+                let text = await getFullLatestResponse(CDP_PORT);
                 text = stripQueryFromResponse(text, query);
                 if (caption) {
                     text = stripQueryFromResponse(text, caption);
                 }
-                // Fallback: if diff is empty, get the full last response
-                if (!text || text === '[No new messages]') {
-                    text = await getFullLatestResponse(CDP_PORT);
-                    text = stripQueryFromResponse(text, query);
-                    if (caption) text = stripQueryFromResponse(text, caption);
-                }
                 if (!text) text = t('ask.done_empty');
+                text = await appendThreadFooter(text);
                 await sendLongMessage(ctx, text, t('ask.done'));
             } else {
                 await ctx.reply(t('ask.timeout'));

--- a/src/ui_locators.js
+++ b/src/ui_locators.js
@@ -1,0 +1,170 @@
+/**
+ * UI Locators Module
+ * 
+ * Centralized registry for all DOM traversal and element querying logic.
+ * This script is injected into the IDE via Chrome DevTools Protocol (CDP) 
+ * prior to evaluating any bot actions.
+ * 
+ * By maintaining a single source of truth for all CSS selectors, the bot 
+ * becomes highly resilient to IDE UI changes and avoids extracting data from 
+ * hidden or stale DOM nodes.
+ */
+
+const UI_LOCATORS_SCRIPT = `
+    var AG_UI = {
+        /**
+         * Retrieves the currently active and visible chat container.
+         * 
+         * Strategy: Anchor from the active chat input element (which the IDE
+         * always places inside the currently focused conversation) and walk
+         * up the DOM tree to the nearest #conversation ancestor. This
+         * guarantees we never accidentally select a stale or background
+         * thread that the IDE keeps mounted in the DOM.
+         * 
+         * Fallback: If the input-based approach fails (e.g. input not yet
+         * rendered), we fall back to querying all candidate containers and
+         * selecting the first one whose entire ancestor chain is visible
+         * (no display:none parents).
+         * 
+         * @returns {HTMLElement|null} The active conversation element
+         */
+        getVisibleChatContainer: () => {
+            // --- Primary strategy: anchor from the active chat input ---
+            const input = AG_UI.getChatInput();
+            if (input) {
+                let el = input;
+                while (el) {
+                    if (el.id === 'conversation' || el.classList.contains('interactive-session')) {
+                        return el;
+                    }
+                    el = el.parentElement;
+                }
+            }
+
+            // --- Fallback: query all candidates and pick the first visible one ---
+            const containers = Array.from(document.querySelectorAll('#conversation, .flex.w-full.grow.flex-col.overflow-hidden, #chat, .interactive-session'));
+            return containers.find(c => {
+                let isVisible = true;
+                let el = c;
+                while (el) {
+                    if (window.getComputedStyle(el).display === 'none') {
+                        isVisible = false;
+                        break;
+                    }
+                    el = el.parentElement;
+                }
+                return isVisible;
+            }) || containers[0] || null;
+        },
+
+        /**
+         * Retrieves the main text area editor used to insert prompts.
+         * Excludes xterm inputs to avoid typing into the terminal.
+         * @returns {HTMLTextAreaElement|HTMLElement|null} The active editor
+         */
+        getChatInput: () => {
+            const editors = [...document.querySelectorAll('.interactive-input-editor textarea, #conversation textarea, #chat textarea, .chat-input textarea, [aria-label*="chat input" i] textarea, [contenteditable="true"]')]
+                .filter(el => !el.className.includes('xterm'));
+            return editors.at(-1) || null;
+        },
+
+        /**
+         * Retrieves the stop/cancel button when the agent is generating.
+         * @returns {HTMLElement|null} The stop button
+         */
+        getStopButton: () => {
+            const chatArea = AG_UI.getVisibleChatContainer() || document;
+            const stopIcon = chatArea.querySelector("svg.lucide-square, [data-tooltip-id*='cancel'], [aria-label*='Stop'], [title*='Stop'], [aria-label*='Cancel']");
+            if (stopIcon) return stopIcon.closest('button') || stopIcon;
+            
+            const allBtns = Array.from(chatArea.querySelectorAll('button'));
+            return allBtns.find(b => {
+                const svg = b.querySelector('svg');
+                return svg && (svg.classList.contains('lucide-square') || b.innerHTML.includes('square'));
+            }) || null;
+        },
+
+        /**
+         * Checks if there are active loading spinners on the page.
+         * Intelligently ignores tiny/hidden status indicator spinners.
+         * @returns {boolean} True if generating/loading
+         */
+        isLoading: () => {
+            return Array.from(document.querySelectorAll('.codicon-loading, .loading, [class*="animate-spin"], [class*="spinner"], [class*="loader"]')).some(el => {
+                if (el.offsetParent === null) return false;
+                if (el.className.includes('h-3') && el.className.includes('w-3')) return false;
+                const parent = el.parentElement;
+                if (parent && (parent.className.includes('opacity-') || parent.className.includes('hidden'))) return false;
+                return true;
+            });
+        },
+
+        /**
+         * Retrieves the 'New Chat' button from the sidebar or header.
+         * @returns {HTMLElement|null}
+         */
+        getNewChatButton: () => {
+            const svgPath = document.querySelector('path[d="M12 4.5v15m7.5-7.5h-15"]');
+            if (svgPath) {
+                const btn = svgPath.closest('button');
+                if (btn) return btn;
+            }
+            return document.querySelector('[aria-label*="New Chat" i], [title*="New Chat" i], [aria-label*="Yeni Sohbet" i], [class*="new-chat"], [aria-label*="New Task" i], [title*="New Task" i]') || null;
+        },
+
+        /**
+         * Retrieves the model selector dropdown button.
+         * @returns {HTMLElement|null}
+         */
+        getModelSelectorButton: () => {
+            return document.querySelector('[aria-label*="Select model" i], [title*="Select model" i], [aria-label*="model" i]') || null;
+        },
+
+        /**
+         * Retrieves the list of available model options when the selector is open.
+         * @returns {HTMLElement[]}
+         */
+        getModelOptions: () => {
+            // Model dropdown items are plain buttons with a specific layout class.
+            // They contain model names like "Gemini 3.1 Pro (High)", "Claude Opus 4.6 (Thinking)", etc.
+            const modelKeywords = ['gemini', 'claude', 'gpt', 'opus', 'sonnet', 'flash'];
+            const candidates = Array.from(document.querySelectorAll('button.px-2.py-1, [role="option"], [role="menuitemradio"]'));
+            // Filter to only those containing model-related text
+            return candidates.filter(el => {
+                const text = (el.textContent || '').toLowerCase();
+                return modelKeywords.some(k => text.includes(k));
+            });
+        },
+
+        /**
+         * Retrieves all workspace cards from the sidebar.
+         * @returns {HTMLElement[]}
+         */
+        getWorkspaceCards: () => {
+            return Array.from(document.querySelectorAll('div[data-workspace-card="true"]'));
+        },
+
+        /**
+         * Retrieves chat thread pills (conversations) either globally or within a specific workspace card.
+         * @param {HTMLElement} [container=document] The container to search within
+         * @returns {HTMLElement[]}
+         */
+        getChatThreadPills: (container = document) => {
+            return Array.from(container.querySelectorAll('[data-testid^="convo-pill-"]'));
+        },
+        
+        /**
+         * Removes "Thought for Xs" blocks from a cloned DOM element.
+         * Useful for message extraction to prevent fetching internal logic.
+         * @param {HTMLElement} clone The cloned message node
+         */
+        removeThoughtBlocks: (clone) => {
+            const btns = Array.from(clone.querySelectorAll('button')).filter(b => b.innerText && b.innerText.includes('Thought for'));
+            btns.forEach(btn => {
+                if (btn.parentElement) btn.parentElement.remove();
+            });
+        }
+    };
+`;
+
+module.exports = { UI_LOCATORS_SCRIPT };


### PR DESCRIPTION
# PR: Centralized UI Locators, Thread Management & New Commands

## Summary

This PR introduces a centralized DOM locator system, adds several new Telegram commands for managing IDE threads and artifacts, migrates chat extraction from DOM scraping to file-system reads for reliability, and adds Markdown rendering for bot responses.

---

## New: Centralized UI Locators (`src/ui_locators.js`)

All DOM selectors used by the bot are now consolidated into a single `UI_LOCATORS_SCRIPT` module. This script is injected via CDP before every interaction, exposing a shared `AG_UI` namespace.

**Key methods:**
- `getVisibleChatContainer()` — Finds the active conversation container
- `getChatInput()` — Retrieves the chat text editor
- `getStopButton()` / `isLoading()` — Agent state detection
- `getNewChatButton()` / `getModelSelectorButton()` — UI control access
- `getWorkspaceCards()` / `getChatThreadPills()` — Sidebar introspection
- `removeThoughtBlocks()` — Strips internal "Thought for Xs" blocks from extraction

All files (`cdp_controller.js`, `index.js`, `autoaccept.js`) now reference this shared module instead of inline selectors.

---

## New: File-System Chat Extraction

Chat content extraction (`/latest`, `/ask` polling) now reads directly from the IDE's conversation log files (`~/.gemini/antigravity/brain/<threadId>/.system_generated/logs/overview.txt`) instead of scraping the DOM.

**Why:** The IDE's workspace DOM can retain stale content from previously-viewed threads. The `#conversation` element doesn't always reflect the currently active thread, making DOM extraction unreliable.

**How it works:**
1. `getActiveThreadId()` queries the Manager target's sidebar pills to identify the highlighted thread
2. The thread's `overview.txt` log is read from disk (JSON-lines format, each entry has a `step_index`)
3. `snapshotChatState` records the current `step_index` as a bookmark
4. `getFullLatestResponse` returns the latest MODEL entry from the log
5. Falls back to DOM extraction if the log file doesn't exist

All response flows (`/ask`, direct messages, photo uploads, `/latest`) now use this file-based extraction exclusively. The legacy DOM-based `getLatestAgentResponse` has been removed.

---

## New: Manager-First Message Sending

`sendViaCDP`, `waitForAgentResponse`, and `isAgentWorking` now prioritize the **Manager** target. The Manager's `#antigravity` input always belongs to the active conversation, while workspace side-panel inputs may correspond to stale threads. This also prevents premature "idle" detection from workspace targets that show no spinners because the actual work is happening on the Manager's active conversation.

---

## Manager-First Model Selection

`triggerModelMenu`, `getAvailableModels`, and `selectModel` now prioritize the Manager target. The model selector button and dropdown live in the Manager's active conversation panel, not in workspace side panels.

Additionally, `getModelOptions()` was updated to correctly identify model dropdown buttons (`button.px-2.py-1` filtered by model keywords) instead of matching unrelated sidebar toolbar items (`[role="menuitem"]`).

---

## New: Dynamic Workspace Detection

`resolveTargets()` now queries the Manager target's top-bar breadcrumb (format: `workspace-name / Thread Title`) to dynamically determine which workspace the user is actively working in. This replaces a hardcoded sort bias and ensures the correct workspace target is prioritized across all commands.

---

## New Commands

### `/agents` — Thread Management
- Lists recent chat threads grouped by workspace, with time labels
- Generates one-tap switch commands (`/agents_1`, `/agents_2`, etc.)
- Supports direct switching via `/agents <number>`

<img width="736" height="366" alt="Screenshot 2026-05-02 at 4 35 17 AM" src="https://github.com/user-attachments/assets/d61c6f6c-8a46-4834-82ec-d05b726db45e" />


### `/artifacts` — Artifact Browser
- Lists files from the active thread's brain storage (markdown, images, videos)
- Displays human-readable timestamps
- Sends media directly: images as photos, videos as video messages, markdown as formatted text

<img width="706" height="469" alt="Screenshot 2026-05-02 at 4 36 12 AM" src="https://github.com/user-attachments/assets/beeca581-eb07-4e55-bca2-0f3cd16dba78" />
<img width="755" height="470" alt="Screenshot 2026-05-02 at 4 36 16 AM" src="https://github.com/user-attachments/assets/829e0207-1314-4c1b-ad73-bca67c79807e" />


---

## New: Markdown → Telegram HTML Rendering

Bot responses are now rendered with proper formatting:
- Headings → **bold**
- `**bold**`, `*italic*` → HTML tags
- Inline code and fenced code blocks → `<code>` / `<pre>`
- Links → clickable `<a href>` tags
- Task lists → emoji checkboxes (✅, ⬜, 🔄)

`sendLongMessage()` handles intelligent chunking that respects code block boundaries and falls back to plain text if HTML parsing fails.

<img width="744" height="323" alt="Screenshot 2026-05-02 at 4 36 57 AM" src="https://github.com/user-attachments/assets/6a9fb1e5-06d8-41da-ae73-3d617787bd87" />


---

## `/help` Reorganization

Split into three sections:
- **Status & Info**: `/latest`, `/screenshot`, `/status`
- **IDE Controls**: `/start_ide`, `/close`, `/workspace`, `/window`, `/lang`, `/cmd`
- **Chat Controls**: `/new`, `/agents`, `/artifacts`, `/model`, `/autoaccept`

<img width="748" height="652" alt="Screenshot 2026-05-02 at 4 32 31 AM" src="https://github.com/user-attachments/assets/2583fe5a-4910-4fcf-9703-27c30ab9db99" />


---

## `/status` & `/latest` Enhancements

**`/status`** now includes a Chat section showing:
- Active workspace and thread name
- Currently selected model
- Agent working status (Working / Idle)

<img width="747" height="399" alt="Screenshot 2026-05-02 at 4 33 55 AM" src="https://github.com/user-attachments/assets/9dcba3f6-b575-4c56-8def-741dd8fd682b" />


**`/latest`** now appends:
- Active workspace / thread name
- Agent status line

<img width="744" height="768" alt="Screenshot 2026-05-02 at 4 34 35 AM" src="https://github.com/user-attachments/assets/2d1b361d-0728-40ea-bce0-124444de5d45" />


---

## Auto-Accept Click Counter Fix

**Race condition on disable**: Added a final click harvest in `disable()` before stopping observers, so clicks between the last heartbeat and the disable command are no longer lost.

**Stale count carryover**: Browser-side click counter is now reset to `0` on every fresh injection, preventing old counts from bleeding into new sessions.

---

## Locale Updates

Added i18n strings in `en.json` and `tr.json` for all new commands (`/agents`, `/artifacts`), the reorganized help sections, and new menu descriptions.

---

## Files Changed

| File | Status | Description |
|------|--------|-------------|
| `src/ui_locators.js` | **New** | Centralized DOM locator module with model selector fix |
| `src/cdp_controller.js` | Modified | File-system extraction, Manager-first sending/model selection, dynamic workspace detection, thread/model functions, removed `getLatestAgentResponse` |
| `src/index.js` | Modified | `/agents`, `/artifacts`, markdown rendering, `/help` reorg, `/latest` enhancements, unified file-based response extraction |
| `src/autoaccept.js` | Modified | Click counter race condition and stale count fixes |
| `locales/en.json` | Modified | New i18n strings |
| `locales/tr.json` | Modified | Corresponding Turkish translations |
| `package-lock.json` | Modified | Dependency lock updates |