### PR TITLE
Fix CDP connection, X11 display auto-detection, and dynamic port shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,264 +1,264 @@
 {
-    "name": "antigravity-telegram-suite",
-    "version": "3.4.0",
-    "lockfileVersion": 3,
-    "requires": true,
-    "packages": {
-        "": {
-            "name": "antigravity-telegram-suite",
-            "version": "3.4.0",
-            "license": "MIT",
-            "dependencies": {
-                "chrome-remote-interface": "^0.34.0",
-                "dotenv": "^17.4.2",
-                "telegraf": "^4.16.3"
-            },
-            "devDependencies": {
-                "husky": "^9.1.7"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@telegraf/types": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
-            "integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==",
-            "license": "MIT"
-        },
-        "node_modules/abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-            "license": "MIT",
-            "dependencies": {
-                "event-target-shim": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=6.5"
-            }
-        },
-        "node_modules/buffer-alloc": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer-alloc-unsafe": "^1.1.0",
-                "buffer-fill": "^1.0.0"
-            }
-        },
-        "node_modules/buffer-alloc-unsafe": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-            "license": "MIT"
-        },
-        "node_modules/buffer-fill": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-            "license": "MIT"
-        },
-        "node_modules/chrome-remote-interface": {
-            "version": "0.34.0",
-            "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.34.0.tgz",
-            "integrity": "sha512-rTTcTZ3zemx8I+nvBii7d8BAF0Ms8LLEroypfvwwZOwSpyNGLE28nStXyCA6VwGp2YSQfmCrQH21F/E+oBFvMw==",
-            "license": "MIT",
-            "dependencies": {
-                "commander": "2.11.x",
-                "ws": "^7.2.0"
-            },
-            "bin": {
-                "chrome-remote-interface": "bin/client.js"
-            }
-        },
-        "node_modules/commander": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-            "license": "MIT"
-        },
-        "node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/dotenv": {
-            "version": "17.4.2",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
-            }
-        },
-        "node_modules/event-target-shim": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/husky": {
-            "version": "9.1.7",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "husky": "bin.js"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/typicode"
-            }
-        },
-        "node_modules/mri": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT"
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/p-timeout": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
-            "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/safe-compare": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
-            "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer-alloc": "^1.2.0"
-            }
-        },
-        "node_modules/sandwich-stream": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
-            "integrity": "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/telegraf": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
-            "integrity": "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==",
-            "license": "MIT",
-            "dependencies": {
-                "@telegraf/types": "^7.1.0",
-                "abort-controller": "^3.0.0",
-                "debug": "^4.3.4",
-                "mri": "^1.2.0",
-                "node-fetch": "^2.7.0",
-                "p-timeout": "^4.1.0",
-                "safe-compare": "^1.1.4",
-                "sandwich-stream": "^2.0.2"
-            },
-            "bin": {
-                "telegraf": "lib/cli.mjs"
-            },
-            "engines": {
-                "node": "^12.20.0 || >=14.13.1"
-            }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
+  "name": "antigravity-telegram-suite",
+  "version": "3.5.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "antigravity-telegram-suite",
+      "version": "3.5.1",
+      "license": "MIT",
+      "dependencies": {
+        "chrome-remote-interface": "^0.34.0",
+        "dotenv": "^17.4.2",
+        "telegraf": "^4.16.3"
+      },
+      "devDependencies": {
+        "husky": "^9.1.7"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@telegraf/types": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
+      "integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==",
+      "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "license": "MIT"
+    },
+    "node_modules/chrome-remote-interface": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.34.0.tgz",
+      "integrity": "sha512-rTTcTZ3zemx8I+nvBii7d8BAF0Ms8LLEroypfvwwZOwSpyNGLE28nStXyCA6VwGp2YSQfmCrQH21F/E+oBFvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "2.11.x",
+        "ws": "^7.2.0"
+      },
+      "bin": {
+        "chrome-remote-interface": "bin/client.js"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safe-compare": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
+      "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc": "^1.2.0"
+      }
+    },
+    "node_modules/sandwich-stream": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
+      "integrity": "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/telegraf": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
+      "integrity": "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==",
+      "license": "MIT",
+      "dependencies": {
+        "@telegraf/types": "^7.1.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.3.4",
+        "mri": "^1.2.0",
+        "node-fetch": "^2.7.0",
+        "p-timeout": "^4.1.0",
+        "safe-compare": "^1.1.4",
+        "sandwich-stream": "^2.0.2"
+      },
+      "bin": {
+        "telegraf": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1835,17 +1835,20 @@ bot.command('app', async (ctx) => {
     const appName = currentApp === 'ide' ? '💻 Classic Monaco IDE' : '🤖 Standalone Agent (2.0)';
     const currentPort = CDP_PORT;
     
+    const agentPort = getCDPPort('agent');
+    const idePort = getCDPPort('ide');
+
     let msg = t('app.selection_title') || `🤖 <b>Antigravity App Selection</b>\n\n`;
     msg += t('app.preferred_app', { appName }) + '\n';
     msg += t('app.active_port', { port: currentPort }) + '\n\n';
     msg += t('app.select_prompt') + '\n';
-    msg += `• <b>Standalone Agent:</b> CDP Port 9333\n`;
-    msg += `• <b>Monaco IDE:</b> CDP Port 9334\n\n`;
+    msg += `• <b>Standalone Agent:</b> CDP Port ${agentPort}\n`;
+    msg += `• <b>Monaco IDE:</b> CDP Port ${idePort}\n\n`;
     msg += t('app.persistent_selection') || `⚡ <i>Your selection is permanently saved to the .env file and applied instantly without restarting the bot.</i>`;
 
     const buttons = [
-        [{ text: '🤖 Standalone Agent (Port: 9333)', callback_data: 'pref_app_agent' }],
-        [{ text: '💻 Classic Monaco IDE (Port: 9334)', callback_data: 'pref_app_ide' }]
+        [{ text: `🤖 Standalone Agent (Port: ${agentPort})`, callback_data: 'pref_app_agent' }],
+        [{ text: `💻 Classic Monaco IDE (Port: ${idePort})`, callback_data: 'pref_app_ide' }]
     ];
 
     ctx.reply(msg, {
@@ -1903,6 +1906,8 @@ bot.command('fix_shortcuts', async (ctx) => {
     
     const platform = require('./platform').PLATFORM;
     const { getAppBinary } = require('./platform');
+    const agentPort = getCDPPort('agent');
+    const idePort = getCDPPort('ide');
     
     if (platform === 'linux') {
         // Linux: Update launcher scripts and .desktop files
@@ -1915,37 +1920,37 @@ bot.command('fix_shortcuts', async (ctx) => {
             // Ensure directories exist
             if (!fs.existsSync(localBin)) fs.mkdirSync(localBin, { recursive: true });
 
-            // --- 1. IDE Launcher (Port 9334) ---
+            // --- 1. IDE Launcher ---
             const ideBinary = getAppBinary('ide');
             const ideLauncherPath = path.join(localBin, 'antigravity-ide-launcher.sh');
             const ideDesktopPath = path.join(desktop, 'Antigravity-IDE-CDP.desktop');
             
             if (fs.existsSync(ideBinary) || fs.existsSync(require('fs').realpathSync(ideBinary).replace(/\/[^/]+$/, ''))) {
-                const ideLauncher = `#!/bin/bash\n# Antigravity IDE Launcher — Port 9334\nPORT=9334\nAPP_PATH="${ideBinary}"\n\n# Check if the IDE is already listening on the port\nLISTENING_PIDS=$(lsof -t -i :$PORT -s TCP:LISTEN 2>/dev/null || true)\n\nif [ -n "$LISTENING_PIDS" ]; then\n    echo "[launcher-ide] IDE already running. Opening a new window..."\n    $APP_PATH "$@"\n    exit 0\nfi\n\necho "[launcher-ide] Starting fresh IDE instance..."\n# Clean up stale locks just in case\nrm -f "$HOME/.config/Antigravity IDE/code.lock"\nrm -f "$HOME/.config/Antigravity-IDE/code.lock"\n\n$APP_PATH --remote-debugging-port=$PORT "$@" &\\nAG_PID=$!\\nwait $AG_PID\\n`;
+                const ideLauncher = `#!/bin/bash\n# Antigravity IDE Launcher — Port ${idePort}\nPORT=${idePort}\nAPP_PATH="${ideBinary}"\n\n# Check if the IDE is already listening on the port\nLISTENING_PIDS=$(lsof -t -i :$PORT -s TCP:LISTEN 2>/dev/null || true)\n\nif [ -n "$LISTENING_PIDS" ]; then\n    echo "[launcher-ide] IDE already running. Opening a new window..."\n    $APP_PATH "$@"\n    exit 0\nfi\n\necho "[launcher-ide] Starting fresh IDE instance..."\n# Clean up stale locks just in case\nrm -f "$HOME/.config/Antigravity IDE/code.lock"\nrm -f "$HOME/.config/Antigravity-IDE/code.lock"\n\n$APP_PATH --remote-debugging-port=$PORT "$@" &\\nAG_PID=$!\\nwait $AG_PID\\n`;
                 fs.writeFileSync(ideLauncherPath, ideLauncher, { mode: 0o755 });
 
-                const ideDesktop = `[Desktop Entry]\nName=Antigravity IDE (CDP 9334)\nComment=Start Antigravity IDE with CDP 9334\nExec=${ideLauncherPath} %F\nIcon=antigravity-ide\nType=Application\nTerminal=false\nStartupNotify=false\nStartupWMClass=antigravity-ide\nCategories=Development;IDE;\nMimeType=application/x-antigravity-workspace;\n`;
+                const ideDesktop = `[Desktop Entry]\nName=Antigravity IDE (CDP ${idePort})\nComment=Start Antigravity IDE with CDP ${idePort}\nExec=${ideLauncherPath} %F\nIcon=antigravity-ide\nType=Application\nTerminal=false\nStartupNotify=false\nStartupWMClass=antigravity-ide\nCategories=Development;IDE;\nMimeType=application/x-antigravity-workspace;\n`;
                 fs.writeFileSync(ideDesktopPath, ideDesktop);
                 exec(`chmod +x "${ideDesktopPath}"`);
-                status += `• 💻 <b>Antigravity IDE</b> -> <code>--remote-debugging-port=9334</code> ✅\n`;
+                status += `• 💻 <b>Antigravity IDE</b> -> <code>--remote-debugging-port=${idePort}</code> ✅\n`;
                 fixedCount++;
             } else {
                 status += `• 💻 <i>Antigravity IDE</i> (${t('shortcuts.binary_not_found')})\n`;
             }
 
-            // --- 2. Standalone Agent (Port 9333) ---
+            // --- 2. Standalone Agent ---
             const agentBinary = getAppBinary('agent');
             const agentLauncherPath = path.join(localBin, 'antigravity-standalone-launcher.sh');
             const agentDesktopPath = path.join(desktop, 'Antigravity-Standalone-CDP.desktop');
             
             if (fs.existsSync(agentBinary)) {
-                const agentLauncher = `#!/bin/bash\n# Antigravity Standalone Launcher — Port 9333\nPORT=9333\nAPP_PATH="${agentBinary}"\n\n# Check if the Standalone App is already listening on the port\nLISTENING_PIDS=$(lsof -t -i :$PORT -s TCP:LISTEN 2>/dev/null || true)\n\nif [ -n "$LISTENING_PIDS" ]; then\n    echo "[launcher-standalone] Standalone App already running. Opening a new window..."\n    $APP_PATH "$@"\n    exit 0\nfi\n\necho "[launcher-standalone] Starting fresh Standalone App instance..."\n# Clean up stale locks just in case\nrm -f "$HOME/.config/Antigravity/code.lock"\n\n$APP_PATH --remote-debugging-port=$PORT "$@" &\\nAG_PID=$!\\nwait $AG_PID\\n`;
+                const agentLauncher = `#!/bin/bash\n# Antigravity Standalone Launcher — Port ${agentPort}\nPORT=${agentPort}\nAPP_PATH="${agentBinary}"\n\n# Check if the Standalone App is already listening on the port\nLISTENING_PIDS=$(lsof -t -i :$PORT -s TCP:LISTEN 2>/dev/null || true)\n\nif [ -n "$LISTENING_PIDS" ]; then\n    echo "[launcher-standalone] Standalone App already running. Opening a new window..."\n    $APP_PATH "$@"\n    exit 0\nfi\n\necho "[launcher-standalone] Starting fresh Standalone App instance..."\n# Clean up stale locks just in case\nrm -f "$HOME/.config/Antigravity/code.lock"\n\n$APP_PATH --remote-debugging-port=$PORT "$@" &\\nAG_PID=$!\\nwait $AG_PID\\n`;
                 fs.writeFileSync(agentLauncherPath, agentLauncher, { mode: 0o755 });
 
-                const agentDesktop = `[Desktop Entry]\nName=Antigravity Standalone (CDP 9333)\nComment=Start Antigravity Standalone Agent with CDP 9333\nExec=${agentLauncherPath} %F\nIcon=antigravity-standalone\nType=Application\nTerminal=false\nStartupNotify=false\nStartupWMClass=antigravity\nCategories=Development;IDE;\nMimeType=application/x-antigravity-workspace;\n`;
+                const agentDesktop = `[Desktop Entry]\nName=Antigravity Standalone (CDP ${agentPort})\nComment=Start Antigravity Standalone Agent with CDP ${agentPort}\nExec=${agentLauncherPath} %F\nIcon=antigravity-standalone\nType=Application\nTerminal=false\nStartupNotify=false\nStartupWMClass=antigravity\nCategories=Development;IDE;\nMimeType=application/x-antigravity-workspace;\n`;
                 fs.writeFileSync(agentDesktopPath, agentDesktop);
                 exec(`chmod +x "${agentDesktopPath}"`);
-                status += `• 🤖 <b>Antigravity Standalone</b> -> <code>--remote-debugging-port=9333</code> ✅\n`;
+                status += `• 🤖 <b>Antigravity Standalone</b> -> <code>--remote-debugging-port=${agentPort}</code> ✅\n`;
                 fixedCount++;
             } else {
                 status += `• 🤖 <i>Antigravity Standalone</i> (${t('shortcuts.binary_not_found')})\n`;
@@ -1963,20 +1968,20 @@ bot.command('fix_shortcuts', async (ctx) => {
 $sh = New-Object -ComObject WScript.Shell
 $desktop = [System.IO.Path]::Combine($env:USERPROFILE, "Desktop")
 
-# 1. Standalone Agent (Port 9333)
+# 1. Standalone Agent (Port ${agentPort})
 $lnkAgent = Join-Path $desktop "Antigravity.lnk"
 if (Test-Path $lnkAgent) {
     $lnk = $sh.CreateShortcut($lnkAgent)
-    $lnk.Arguments = "--remote-debugging-port=9333"
+    $lnk.Arguments = "--remote-debugging-port=${agentPort}"
     $lnk.Save()
     Write-Output "agent-fixed"
 }
 
-# 2. Classic IDE (Port 9334)
+# 2. Classic IDE (Port ${idePort})
 $lnkIDE = Join-Path $desktop "Antigravity IDE.lnk"
 if (Test-Path $lnkIDE) {
     $lnk = $sh.CreateShortcut($lnkIDE)
-    $lnk.Arguments = "--remote-debugging-port=9334"
+    $lnk.Arguments = "--remote-debugging-port=${idePort}"
     $lnk.Save()
     Write-Output "ide-fixed"
 }
@@ -1996,13 +2001,13 @@ if (Test-Path $lnkIDE) {
                 const output = stdout.toLowerCase();
                 let fixedCount = 0;
                 if (output.includes('agent-fixed')) {
-                    status += '\u2022 \ud83e\udd16 <b>Antigravity.lnk</b> -> <code>--remote-debugging-port=9333</code> \u2705\n';
+                    status += `\u2022 \ud83e\udd16 <b>Antigravity.lnk</b> -> <code>--remote-debugging-port=${agentPort}</code> \u2705\n`;
                     fixedCount++;
                 } else {
                     status += '\u2022 \ud83e\udd16 <i>Antigravity.lnk</i> (' + t('shortcuts.not_found') + ')\n';
                 }
                 if (output.includes('ide-fixed')) {
-                    status += '\u2022 \ud83d\udcbb <b>Antigravity IDE.lnk</b> -> <code>--remote-debugging-port=9334</code> \u2705\n';
+                    status += `\u2022 \ud83d\udcbb <b>Antigravity IDE.lnk</b> -> <code>--remote-debugging-port=${idePort}</code> \u2705\n`;
                     fixedCount++;
                 } else {
                     status += '\u2022 \ud83d\udcbb <i>Antigravity IDE.lnk</i> (' + t('shortcuts.not_found') + ')\n';
@@ -2022,24 +2027,24 @@ if (Test-Path $lnkIDE) {
             let fixedCount = 0;
             let status = t('shortcuts.updated');
             
-            // 1. Standalone Agent (Port 9333)
+            // 1. Standalone Agent (Port ${agentPort})
             const agentBinary = getAppBinary('agent'); // Uygulamanın .app dizinini döndürür
             if (fs.existsSync(agentBinary)) {
                 const agentAppPath = path.join(desktop, 'Antigravity Agent (CDP).app');
                 // open -a komutuyla uygulamayı debug portu ile başlatacak script
-                const script = `do shell script "open -a \\"${agentBinary}\\" --args --remote-debugging-port=9333"`;
+                const script = `do shell script "open -a \\"${agentBinary}\\" --args --remote-debugging-port=${agentPort}"`;
                 execSync(`osacompile -e '${script}' -o "${agentAppPath}"`);
-                status += `• 🤖 <b>Antigravity Agent (CDP).app</b> -> <code>Port 9333</code> ✅\n`;
+                status += `• 🤖 <b>Antigravity Agent (CDP).app</b> -> <code>Port ${agentPort}</code> ✅\n`;
                 fixedCount++;
             }
             
-            // 2. Classic IDE (Port 9334)
+            // 2. Classic IDE (Port ${idePort})
             const ideBinary = getAppBinary('ide');
             if (fs.existsSync(ideBinary)) {
                 const ideAppPath = path.join(desktop, 'Antigravity IDE (CDP).app');
-                const script = `do shell script "open -a \\"${ideBinary}\\" --args --remote-debugging-port=9334"`;
+                const script = `do shell script "open -a \\"${ideBinary}\\" --args --remote-debugging-port=${idePort}"`;
                 execSync(`osacompile -e '${script}' -o "${ideAppPath}"`);
-                status += `• 💻 <b>Antigravity IDE (CDP).app</b> -> <code>Port 9334</code> ✅\n`;
+                status += `• 💻 <b>Antigravity IDE (CDP).app</b> -> <code>Port ${idePort}</code> ✅\n`;
                 fixedCount++;
             }
             

--- a/src/platform.js
+++ b/src/platform.js
@@ -93,7 +93,7 @@ function getAppBinary(app = getPreferredApp()) {
             case 'win32':
                 return path.join(process.env.LOCALAPPDATA || '', 'Programs', 'Antigravity', 'Antigravity IDE.exe');
             default: // linux
-                return '/usr/local/bin/antigravity-ide';
+                return '/opt/antigravity-ide/antigravity-ide';
         }
     } else {
         // agent (standalone)
@@ -107,7 +107,7 @@ function getAppBinary(app = getPreferredApp()) {
             case 'win32':
                 return path.join(process.env.LOCALAPPDATA || '', 'Programs', 'Antigravity', 'Antigravity.exe');
             default: // linux
-                return '/usr/bin/antigravity';
+                return '/opt/antigravity/antigravity';
         }
     }
 }
@@ -450,6 +450,36 @@ function launchIDE(workspace, port = 9333, app = getPreferredApp()) {
             delete cleanEnv.VSCODE_CODE_CACHE_PATH;
             delete cleanEnv.WAYLAND_DISPLAY;
             delete cleanEnv.GDK_BACKEND;  // LINUX SAFETY: Prevent Wayland crash (RustDesk)
+
+            // Auto-detect X11 DISPLAY and XAUTHORITY on Linux (e.g. when running under systemd user service)
+            if (PLATFORM === 'linux') {
+                if (!cleanEnv.DISPLAY) {
+                    try {
+                        const fs = require('fs');
+                        const files = fs.readdirSync('/tmp/.X11-unix');
+                        const xSocket = files.find(f => f.startsWith('X'));
+                        if (xSocket) {
+                            cleanEnv.DISPLAY = `:${xSocket.substring(1)}`;
+                            console.log(`[platform] Auto-detected DISPLAY=${cleanEnv.DISPLAY}`);
+                        }
+                    } catch (e) {
+                        console.error('[platform] Failed to auto-detect DISPLAY:', e.message);
+                    }
+                }
+                if (!cleanEnv.XAUTHORITY) {
+                    try {
+                        const fs = require('fs');
+                        const xauth = path.join(HOME, '.Xauthority');
+                        if (fs.existsSync(xauth)) {
+                            cleanEnv.XAUTHORITY = xauth;
+                            console.log(`[platform] Auto-detected XAUTHORITY=${cleanEnv.XAUTHORITY}`);
+                        }
+                    } catch (_) {}
+                }
+                if (cleanEnv.DISPLAY) {
+                    cleanEnv.GDK_BACKEND = 'x11';
+                }
+            }
 
             if (isRunning && PLATFORM === 'linux') {
                 const { execSync } = require('child_process');

--- a/src/watchdog.js
+++ b/src/watchdog.js
@@ -33,7 +33,7 @@ function spawnBot() {
         fs.writeFileSync(HEARTBEAT_FILE, Date.now().toString(), 'utf8');
     } catch (_) {}
 
-    botProcess = spawn('node', [BOT_SCRIPT], {
+    botProcess = spawn(process.execPath, [BOT_SCRIPT], {
         cwd: PROJECT_ROOT,
         env: { ...process.env, WATCHDOG: 'true' },
         stdio: 'inherit' // Automatically forwards stdout, stderr, and stdin


### PR DESCRIPTION
This PR fixes several critical issues with CDP connection and auto-start under background services:

1. **X11 Display Auto-Detection (Linux GUI Crash Fix):** Dynamically scans for X11 display sockets in `/tmp/.X11-unix` and finds `~/.Xauthority` to configure DISPLAY and XAUTHORITY. This prevents Electron crashes when launching from a systemd user service.
2. **IDE Binary Path Correction:** Resolves `getAppBinary('ide')` directly to the raw Electron binary executable rather than the wrapper CLI shell script, allowing proper IPC resolution and startup.
3. **Dynamic Port Shortcuts Fix:** Replaces hardcoded port definitions (9333/9334) with configured values in the `/app` select title and the `/fix_shortcuts` command, avoiding port mismatches.