### PR TITLE
fix(core): prevent killing other app on switch if ports do not conflict

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3096,8 +3096,12 @@ bot.action(/pref_app_(.+)/, async (ctx) => {
     const success = updateEnvFile('ANTIGRAVITY_PREFERRED_APP', selectedApp);
     
     if (success) {
-        // Eski uygulamayı güvenli bir şekilde kapat (UI'ı bloklamadan arka planda)
-        const killPromise = killIDE(oldApp).catch(e => console.error('[App Switch] Failed to kill old app:', e.message));
+        // Only kill the old app if they share the exact same port (to free it up).
+        // If they are configured on different ports, both can run concurrently.
+        let killPromise = Promise.resolve();
+        if (getCDPPort('agent') === getCDPPort('ide')) {
+            killPromise = killIDE(oldApp).catch(e => console.error('[App Switch] Failed to kill old app:', e.message));
+        }
         
         // Recalculate port
         CDP_PORT = getCDPPort();


### PR DESCRIPTION
### Bug Description
In version `3.8.0` (commit `3b227b57`), a "Seamless App Switching" feature was introduced. When switching target applications via the `/app` command in Telegram, the bot unconditionally executes a `killIDE(oldApp)` call to terminate the previously active application process. 

This causes major disruptions for setups where the user intends to run both the Standalone Agent and Monaco IDE concurrently using different ports (e.g., `AGENT_CDP_PORT=9333` and `IDE_CDP_PORT=9334`). Switching the bot's target focus in Telegram kills the other application on the user's host machine, making concurrent usage impossible and leading to connection refusal/heartbeat errors when switching.

### Proposed Fix
Modify the `pref_app_` action callback in `src/index.js` to only execute `killIDE(oldApp)` if `getCDPPort('agent') === getCDPPort('ide')` (i.e. when they share the exact same port and must free it up). 

If the apps are configured to run on separate, non-conflicting ports, both processes are allowed to remain active, and the bot will cleanly switch focus/ports without terminating either application.
